### PR TITLE
feat(connect): upgrade to apache httpclient 5.x

### DIFF
--- a/clients/java/client/pom.xml
+++ b/clients/java/client/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>
       <artifactId>httpclient5</artifactId>
-      <version>${version.httpclient5}</version>
+      <version>${version.httpclient}</version>
     </dependency>
 
     <dependency>

--- a/connect/README.md
+++ b/connect/README.md
@@ -2,7 +2,7 @@ camunda-connect
 ===============
 
 <p>
-  <a href="http://camunda.com/">Home</a> |
+  <a href="https://camunda.com/">Home</a> |
   <a href="https://docs.camunda.org/manual/latest/reference/connect/">Documentation</a> |
   <a href="https://forum.camunda.org/">Forum</a> |
   <a href="https://jira.camunda.com/browse/CAM">Issues</a> |
@@ -12,14 +12,14 @@ camunda-connect
 
 Simple API for connecting HTTP Services and other things.
 
-# List of connectors
+# List of Connectors
 
-* HTTP Connector
-* SOAP HTTP Connector
+* HTTP Connector (using Apache HttpClient 5.x)
+* SOAP HTTP Connector (using Apache HttpClient 5.x)
 
 # Using a Connector
 
-camunda Connect API aims at two usage scenarios, usage in a generic system such as Camunda Platform
+Camunda Connect API aims at two usage scenarios, usage in a generic system such as Camunda Platform
 process engine and standalone usage via API. Please see the [official documentation](https://docs.camunda.org/manual/latest/reference/connect/) for more information.
 
 # Contributing
@@ -27,10 +27,7 @@ process engine and standalone usage via API. Please see the [official documentat
 Have a look at our [contribution guide](https://github.com/camunda/camunda-bpm-platform/blob/master/CONTRIBUTING.md) for how to contribute to this repository.
 
 
-# License:
+# License
 
 The source files in this repository are made available under the <a href="../LICENSE">Apache License, Version 2.0</a>.
 
-
-
-[CONTRIBUTING.md]: https://github.com/camunda/camunda-bpm-platform/blob/master/CONTRIBUTING.md

--- a/connect/core/src/main/java/org/cibseven/connect/Connectors.java
+++ b/connect/core/src/main/java/org/cibseven/connect/Connectors.java
@@ -40,7 +40,7 @@ public class Connectors {
   public static String SOAP_HTTP_CONNECTOR_ID = "soap-http-connector";
 
   /** The global instance of the manager */
-  static Connectors INSTANCE = new Connectors();
+  static final Connectors INSTANCE = new Connectors();
 
   /**
    * Provides the global instance of the Connectors manager.
@@ -54,27 +54,24 @@ public class Connectors {
    * @return the connector for the default http connector id or null if
    * no connector is registered for this id
    */
-  @SuppressWarnings("unchecked")
   public static <C extends Connector<? extends ConnectorRequest<?>>> C http() {
-    return (C) INSTANCE.getConnectorById(HTTP_CONNECTOR_ID);
+    return getConnector(HTTP_CONNECTOR_ID);
   }
 
   /**
    * @return the connector for the default soap http connector id or null
    * if no connector is registered for this id
    */
-  @SuppressWarnings("unchecked")
   public static <C extends Connector<? extends ConnectorRequest<?>>> C soap() {
-    return (C) INSTANCE.getConnectorById(SOAP_HTTP_CONNECTOR_ID);
+    return getConnector(SOAP_HTTP_CONNECTOR_ID);
   }
 
   /**
    * @return the connector for the given id or null if no connector is
    * registered for this id
    */
-  @SuppressWarnings("unchecked")
   public static <C extends Connector<? extends ConnectorRequest<?>>> C getConnector(String connectorId) {
-    return (C) INSTANCE.getConnectorById(connectorId);
+    return INSTANCE.getConnectorById(connectorId);
   }
 
   /**
@@ -126,7 +123,7 @@ public class Connectors {
    */
   public Set<Connector<? extends ConnectorRequest<?>>> getAllAvailableConnectors() {
     ensureConnectorProvidersInitialized();
-    return new HashSet<Connector<?>>(availableConnectors.values());
+    return new HashSet<>(availableConnectors.values());
   }
 
   /**
@@ -153,9 +150,9 @@ public class Connectors {
   }
 
   protected void initializeConnectors(ClassLoader classLoader) {
-    Map<String, Connector<?>> connectors = new HashMap<String, Connector<?>>();
+    Map<String, Connector<?>> connectors = new HashMap<>();
 
-    if(classLoader == null) {
+    if (classLoader == null) {
       classLoader = Connectors.class.getClassLoader();
     }
 
@@ -181,8 +178,7 @@ public class Connectors {
     String connectorId = provider.getConnectorId();
     if (connectors.containsKey(connectorId)) {
       throw LOG.multipleConnectorProvidersFound(connectorId);
-    }
-    else {
+    } else {
       Connector<?> connectorInstance = provider.createConnectorInstance();
       LOG.connectorProviderDiscovered(provider, connectorId, connectorInstance);
       connectors.put(connectorId, connectorInstance);

--- a/connect/core/src/main/java/org/cibseven/connect/impl/AbstractCloseableConnectorResponse.java
+++ b/connect/core/src/main/java/org/cibseven/connect/impl/AbstractCloseableConnectorResponse.java
@@ -30,7 +30,7 @@ import org.cibseven.connect.spi.CloseableConnectorResponse;
  */
 public abstract class AbstractCloseableConnectorResponse extends AbstractConnectorResponse implements CloseableConnectorResponse {
 
-  private final static ConnectCoreLogger LOG = ConnectLogger.CORE_LOGGER;
+  private static final ConnectCoreLogger LOG = ConnectLogger.CORE_LOGGER;
 
   /**
    * Implements the default close behavior

--- a/connect/core/src/main/java/org/cibseven/connect/impl/AbstractConnector.java
+++ b/connect/core/src/main/java/org/cibseven/connect/impl/AbstractConnector.java
@@ -27,7 +27,7 @@ import org.cibseven.connect.spi.ConnectorRequestInterceptor;
 
 /**
  * Abstract implementation of the connector interface.
- *
+ * <p>
  * This implementation provides a linked list of interceptors and related methods for
  * handling interceptor invocation.
  *
@@ -41,9 +41,9 @@ public abstract class AbstractConnector<Q extends ConnectorRequest<R>, R extends
   /**
    * The {@link ConnectorRequestInterceptor} chain
    */
-  protected List<ConnectorRequestInterceptor> requestInterceptors = new LinkedList<ConnectorRequestInterceptor>();
+  protected List<ConnectorRequestInterceptor> requestInterceptors = new LinkedList<>();
 
-  public AbstractConnector(String connectorId) {
+  protected AbstractConnector(String connectorId) {
     this.connectorId = connectorId;
   }
 

--- a/connect/core/src/main/java/org/cibseven/connect/impl/AbstractConnectorRequest.java
+++ b/connect/core/src/main/java/org/cibseven/connect/impl/AbstractConnectorRequest.java
@@ -32,15 +32,15 @@ public abstract class AbstractConnectorRequest<R extends ConnectorResponse> impl
 
   protected Connector connector;
 
-  protected Map<String, Object> requestParameters = new HashMap<String, Object>();
+  protected Map<String, Object> requestParameters = new HashMap<>();
 
-  public AbstractConnectorRequest(Connector connector) {
+  protected AbstractConnectorRequest(Connector connector) {
     this.connector = connector;
   }
 
   @SuppressWarnings("unchecked")
   public R execute() {
-    if(!isRequestValid()) {
+    if (!isRequestValid()) {
       throw new RuntimeException("The request is invalid");
     }
     return (R) connector.execute(this);

--- a/connect/core/src/main/java/org/cibseven/connect/impl/AbstractConnectorResponse.java
+++ b/connect/core/src/main/java/org/cibseven/connect/impl/AbstractConnectorResponse.java
@@ -30,8 +30,8 @@ public abstract class AbstractConnectorResponse implements ConnectorResponse {
   protected Map<String, Object> responseParameters;
 
   public Map<String, Object> getResponseParameters() {
-    if(responseParameters == null) {
-      responseParameters = new HashMap<String, Object>();
+    if (responseParameters == null) {
+      responseParameters = new HashMap<>();
       collectResponseParameters(responseParameters);
     }
     return responseParameters;

--- a/connect/core/src/main/java/org/cibseven/connect/impl/AbstractRequestInvocation.java
+++ b/connect/core/src/main/java/org/cibseven/connect/impl/AbstractRequestInvocation.java
@@ -18,8 +18,8 @@ package org.cibseven.connect.impl;
 
 import java.util.List;
 
-import org.cibseven.connect.spi.ConnectorRequest;
 import org.cibseven.connect.spi.ConnectorInvocation;
+import org.cibseven.connect.spi.ConnectorRequest;
 import org.cibseven.connect.spi.ConnectorRequestInterceptor;
 
 /**
@@ -40,7 +40,7 @@ public abstract class AbstractRequestInvocation<T> implements ConnectorInvocatio
 
   protected ConnectorRequest<?> request;
 
-  public AbstractRequestInvocation(T target, ConnectorRequest<?> request, List<ConnectorRequestInterceptor> interceptorChain) {
+  protected AbstractRequestInvocation(T target, ConnectorRequest<?> request, List<ConnectorRequestInterceptor> interceptorChain) {
     this.target = target;
     this.request = request;
     this.interceptorChain = interceptorChain;
@@ -57,7 +57,7 @@ public abstract class AbstractRequestInvocation<T> implements ConnectorInvocatio
 
   public Object proceed() throws Exception {
     currentIndex++;
-    if(interceptorChain.size() > currentIndex) {
+    if (interceptorChain.size() > currentIndex) {
       return interceptorChain.get(currentIndex).handleInvocation(this);
 
     } else {

--- a/connect/core/src/main/java/org/cibseven/connect/impl/ConnectLogger.java
+++ b/connect/core/src/main/java/org/cibseven/connect/impl/ConnectLogger.java
@@ -22,6 +22,6 @@ public abstract class ConnectLogger extends BaseLogger {
 
   public static final String PROJECT_CODE = "CNCT";
 
-  public static ConnectCoreLogger CORE_LOGGER = createLogger(ConnectCoreLogger.class, PROJECT_CODE, "org.cibseven.bpm.connect", "01");
+  public static final ConnectCoreLogger CORE_LOGGER = createLogger(ConnectCoreLogger.class, PROJECT_CODE, "org.cibseven.bpm.connect", "01");
 
 }

--- a/connect/core/src/main/java/org/cibseven/connect/impl/DebugRequestInterceptor.java
+++ b/connect/core/src/main/java/org/cibseven/connect/impl/DebugRequestInterceptor.java
@@ -17,8 +17,8 @@
 package org.cibseven.connect.impl;
 
 import org.cibseven.connect.spi.ConnectorInvocation;
-import org.cibseven.connect.spi.ConnectorRequestInterceptor;
 import org.cibseven.connect.spi.ConnectorRequest;
+import org.cibseven.connect.spi.ConnectorRequestInterceptor;
 
 /**
  * <p>
@@ -60,8 +60,7 @@ public class DebugRequestInterceptor implements ConnectorRequestInterceptor {
     target = invocation.getTarget();
     if (proceed) {
       return invocation.proceed();
-    }
-    else {
+    } else {
       return response;
     }
   }

--- a/connect/core/src/main/java/org/cibseven/connect/spi/CloseableConnectorResponse.java
+++ b/connect/core/src/main/java/org/cibseven/connect/spi/CloseableConnectorResponse.java
@@ -27,6 +27,6 @@ package org.cibseven.connect.spi;
  */
 public interface CloseableConnectorResponse extends ConnectorResponse {
 
-  public void close();
+  void close();
 
 }

--- a/connect/core/src/main/java/org/cibseven/connect/spi/Connector.java
+++ b/connect/core/src/main/java/org/cibseven/connect/spi/Connector.java
@@ -87,4 +87,5 @@ public interface Connector<Q extends ConnectorRequest<?>> {
    * @return the result.
    */
   ConnectorResponse execute(Q request);
+
 }

--- a/connect/core/src/main/java/org/cibseven/connect/spi/ConnectorInvocation.java
+++ b/connect/core/src/main/java/org/cibseven/connect/spi/ConnectorInvocation.java
@@ -30,7 +30,7 @@ public interface ConnectorInvocation {
    * The underlying raw request.
    * @return the raw request as executed by the connector
    */
-  public Object getTarget();
+  Object getTarget();
 
   /**
    * <p>The connector request as created through the API. Accessing the request from an
@@ -42,7 +42,7 @@ public interface ConnectorInvocation {
    *
    * @return the connector request
    */
-  public ConnectorRequest<?> getRequest();
+  ConnectorRequest<?> getRequest();
 
   /**
    * Makes the request proceed through the interceptor chain.
@@ -52,6 +52,6 @@ public interface ConnectorInvocation {
    * @return the result of the invocation.
    * @throws Exception
    */
-  public Object proceed() throws Exception;
+  Object proceed() throws Exception;
 
 }

--- a/connect/core/src/test/java/org/cibseven/connect/spi/ConnectorsTest.java
+++ b/connect/core/src/test/java/org/cibseven/connect/spi/ConnectorsTest.java
@@ -18,8 +18,6 @@ package org.cibseven.connect.spi;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Set;
-
 import org.cibseven.connect.Connectors;
 import org.cibseven.connect.dummy.DummyConnector;
 import org.junit.Test;

--- a/connect/http-client/pom.xml
+++ b/connect/http-client/pom.xml
@@ -19,15 +19,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-    </dependency>
-    <!-- commons-codec is a transitive dependency of httpclient;
-      we override its version here in order to update the default commons-codec
-      version which has known vulnerabilities, see https://jira.camunda.com/browse/CAM-12774 -->
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
     </dependency>
 
     <dependency>

--- a/connect/http-client/src/main/java/org/cibseven/connect/httpclient/HttpConnector.java
+++ b/connect/http-client/src/main/java/org/cibseven/connect/httpclient/HttpConnector.java
@@ -21,6 +21,6 @@ import org.cibseven.connect.spi.Connector;
 
 public interface HttpConnector extends Connector<HttpRequest> {
 
-  static final String ID = Connectors.HTTP_CONNECTOR_ID;
+  String ID = Connectors.HTTP_CONNECTOR_ID;
 
 }

--- a/connect/http-client/src/main/java/org/cibseven/connect/httpclient/HttpResponse.java
+++ b/connect/http-client/src/main/java/org/cibseven/connect/httpclient/HttpResponse.java
@@ -22,9 +22,9 @@ import org.cibseven.connect.spi.CloseableConnectorResponse;
 
 public interface HttpResponse extends CloseableConnectorResponse {
 
-  static final String PARAM_NAME_STATUS_CODE = "statusCode";
-  static final String PARAM_NAME_RESPONSE = "response";
-  static final String PARAM_NAME_RESPONSE_HEADERS = "headers";
+  String PARAM_NAME_STATUS_CODE = "statusCode";
+  String PARAM_NAME_RESPONSE = "response";
+  String PARAM_NAME_RESPONSE_HEADERS = "headers";
 
   /**
    * @return the HTTP status code of the response

--- a/connect/http-client/src/main/java/org/cibseven/connect/httpclient/impl/AbstractHttpConnector.java
+++ b/connect/http-client/src/main/java/org/cibseven/connect/httpclient/impl/AbstractHttpConnector.java
@@ -18,25 +18,27 @@ package org.cibseven.connect.httpclient.impl;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Optional;
 
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.config.RequestConfig.Builder;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpOptions;
-import org.apache.http.client.methods.HttpPatch;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.client.methods.HttpTrace;
-import org.apache.http.entity.InputStreamEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.hc.client5.http.classic.methods.HttpDelete;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpHead;
+import org.apache.hc.client5.http.classic.methods.HttpOptions;
+import org.apache.hc.client5.http.classic.methods.HttpPatch;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpPut;
+import org.apache.hc.client5.http.classic.methods.HttpTrace;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.config.RequestConfig.Builder;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.io.entity.InputStreamEntity;
+import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
 import org.cibseven.connect.httpclient.HttpBaseRequest;
 import org.cibseven.connect.httpclient.HttpResponse;
 import org.cibseven.connect.httpclient.impl.util.ParseUtil;
@@ -44,15 +46,15 @@ import org.cibseven.connect.impl.AbstractConnector;
 
 public abstract class AbstractHttpConnector<Q extends HttpBaseRequest<Q, R>, R extends HttpResponse> extends AbstractConnector<Q, R> {
 
-  protected static HttpConnectorLogger LOG = HttpLogger.HTTP_LOGGER;
+  protected static final HttpConnectorLogger LOG = HttpLogger.HTTP_LOGGER;
 
   protected CloseableHttpClient httpClient;
   protected final Charset charset;
 
-  public AbstractHttpConnector(String connectorId) {
+  protected AbstractHttpConnector(String connectorId) {
     super(connectorId);
     httpClient = createClient();
-    charset = Charset.forName("utf-8");
+    charset = StandardCharsets.UTF_8;
   }
 
   protected CloseableHttpClient createClient() {
@@ -70,10 +72,10 @@ public abstract class AbstractHttpConnector<Q extends HttpBaseRequest<Q, R>, R e
   @Override
   public R execute(Q request) {
     R invocationResult;
-    HttpRequestBase httpRequest = createHttpRequest(request);
+    BasicClassicHttpRequest httpRequest = createHttpRequest(request);
     HttpRequestInvocation invocation = new HttpRequestInvocation(httpRequest, request, requestInterceptors, httpClient);
     try {
-      invocationResult = createResponse((CloseableHttpResponse) invocation.proceed());
+      invocationResult = createResponse((ClassicHttpResponse) invocation.proceed());
     } catch (Exception e) {
       throw LOG.unableToExecuteRequest(e);
     }
@@ -93,18 +95,15 @@ public abstract class AbstractHttpConnector<Q extends HttpBaseRequest<Q, R>, R e
     }
   }
 
-  protected abstract R createResponse(CloseableHttpResponse response);
-
-  @Override
-  public abstract Q createRequest();
+  protected abstract R createResponse(ClassicHttpResponse response);
 
   /**
-   * creates a apache Http* representation of the request.
+   * creates a apache Http representation of the request.
    *
    * @param request the given request
-   * @return {@link HttpRequestBase} an apache representation of the request
+   * @return {@link BasicClassicHttpRequest} an apache representation of the request
    */
-  protected <T extends HttpRequestBase> T createHttpRequest(Q request) {
+  protected <T extends BasicClassicHttpRequest> T createHttpRequest(Q request) {
     T httpRequest = createHttpRequestBase(request);
 
     applyConfig(httpRequest, request.getConfigOptions());
@@ -117,7 +116,7 @@ public abstract class AbstractHttpConnector<Q extends HttpBaseRequest<Q, R>, R e
   }
 
   @SuppressWarnings("unchecked")
-  protected <T extends HttpRequestBase> T createHttpRequestBase(Q request) {
+  protected <T extends BasicClassicHttpRequest> T createHttpRequestBase(Q request) {
     String url = request.getUrl();
     if (url != null && !url.trim().isEmpty()) {
       String method = request.getMethod();
@@ -140,13 +139,12 @@ public abstract class AbstractHttpConnector<Q extends HttpBaseRequest<Q, R>, R e
       } else {
         throw LOG.unknownHttpMethod(method);
       }
-    }
-    else {
+    } else {
       throw LOG.requestUrlRequired();
     }
   }
 
-  protected <T extends HttpRequestBase> void applyHeaders(T httpRequest, Map<String, String> headers) {
+  protected <T extends BasicClassicHttpRequest> void applyHeaders(T httpRequest, Map<String, String> headers) {
     if (headers != null) {
       for (Map.Entry<String, String> entry : headers.entrySet()) {
         httpRequest.setHeader(entry.getKey(), entry.getValue());
@@ -155,31 +153,32 @@ public abstract class AbstractHttpConnector<Q extends HttpBaseRequest<Q, R>, R e
     }
   }
 
-  protected <T extends HttpRequestBase> void applyPayload(T httpRequest, Q request) {
+  protected <T extends BasicClassicHttpRequest> void applyPayload(T httpRequest, Q request) {
     if (httpMethodSupportsPayload(httpRequest)) {
       if (request.getPayload() != null) {
         byte[] bytes = request.getPayload().getBytes(charset);
         ByteArrayInputStream payload = new ByteArrayInputStream(bytes);
-        InputStreamEntity entity = new InputStreamEntity(payload, bytes.length);
-        ((HttpEntityEnclosingRequestBase) httpRequest).setEntity(entity);
+        InputStreamEntity entity = new InputStreamEntity(payload, bytes.length, ContentType.parse(request.getContentType()));
+        httpRequest.setEntity(entity);
       }
-    }
-    else if (request.getPayload() != null) {
+    } else if (request.getPayload() != null) {
       LOG.payloadIgnoredForHttpMethod(request.getMethod());
     }
   }
 
-  protected <T extends HttpRequestBase> boolean httpMethodSupportsPayload(T httpRequest) {
-    return httpRequest instanceof HttpEntityEnclosingRequestBase;
+  protected <T extends BasicClassicHttpRequest> boolean httpMethodSupportsPayload(T httpRequest) {
+    return httpRequest instanceof HttpUriRequestBase;
   }
 
-  protected <T extends HttpRequestBase> void applyConfig(T httpRequest, Map<String, Object> configOptions) {
-    Builder configBuilder = RequestConfig.custom();
-    if (configOptions != null && !configOptions.isEmpty()) {
-      ParseUtil.parseConfigOptions(configOptions, configBuilder);
+  protected <T extends BasicClassicHttpRequest> void applyConfig(T httpRequest, Map<String, Object> configOptions) {
+    if (httpMethodSupportsPayload(httpRequest)) {
+      Builder configBuilder = RequestConfig.custom();
+      if (configOptions != null && !configOptions.isEmpty()) {
+        ParseUtil.parseConfigOptions(configOptions, configBuilder);
+      }
+      RequestConfig requestConfig = configBuilder.build();
+      ((HttpUriRequestBase) httpRequest).setConfig(requestConfig);
     }
-    RequestConfig requestConfig = configBuilder.build();
-    httpRequest.setConfig(requestConfig);
   }
 
 

--- a/connect/http-client/src/main/java/org/cibseven/connect/httpclient/impl/AbstractHttpRequest.java
+++ b/connect/http-client/src/main/java/org/cibseven/connect/httpclient/impl/AbstractHttpRequest.java
@@ -19,14 +19,14 @@ package org.cibseven.connect.httpclient.impl;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpOptions;
-import org.apache.http.client.methods.HttpPatch;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpTrace;
+import org.apache.hc.client5.http.classic.methods.HttpDelete;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpHead;
+import org.apache.hc.client5.http.classic.methods.HttpOptions;
+import org.apache.hc.client5.http.classic.methods.HttpPatch;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpPut;
+import org.apache.hc.client5.http.classic.methods.HttpTrace;
 import org.cibseven.connect.httpclient.HttpBaseRequest;
 import org.cibseven.connect.httpclient.HttpResponse;
 import org.cibseven.connect.impl.AbstractConnectorRequest;
@@ -34,7 +34,7 @@ import org.cibseven.connect.spi.Connector;
 
 public class AbstractHttpRequest<Q extends HttpBaseRequest<?, ?>, R extends HttpResponse> extends AbstractConnectorRequest<R> {
 
-  private final HttpConnectorLogger LOG = HttpLogger.HTTP_LOGGER;
+  private static final HttpConnectorLogger LOG = HttpLogger.HTTP_LOGGER;
 
   public AbstractHttpRequest(Connector connector) {
     super(connector);
@@ -64,12 +64,11 @@ public class AbstractHttpRequest<Q extends HttpBaseRequest<?, ?>, R extends Http
   public Q header(String field, String value) {
     if (field == null || field.isEmpty() || value == null || value.isEmpty()) {
       LOG.ignoreHeader(field, value);
-    }
-    else {
+    } else {
       Map<String, String> headers = getRequestParameter(HttpBaseRequest.PARAM_NAME_REQUEST_HEADERS);
 
       if (headers == null) {
-        headers = new HashMap<String, String>();
+        headers = new HashMap<>();
         setRequestParameter(HttpBaseRequest.PARAM_NAME_REQUEST_HEADERS, headers);
       }
       headers.put(field, value);
@@ -82,8 +81,7 @@ public class AbstractHttpRequest<Q extends HttpBaseRequest<?, ?>, R extends Http
     Map<String, String> headers = getHeaders();
     if (headers != null) {
       return headers.get(field);
-    }
-    else {
+    } else {
       return null;
     }
   }
@@ -163,7 +161,7 @@ public class AbstractHttpRequest<Q extends HttpBaseRequest<?, ?>, R extends Http
       Map<String, Object> config = getConfigOptions();
 
       if (config == null) {
-        config = new HashMap<String, Object>();
+        config = new HashMap<>();
         setRequestParameter(HttpBaseRequest.PARAM_NAME_REQUEST_CONFIG, config);
       }
       config.put(field, value);

--- a/connect/http-client/src/main/java/org/cibseven/connect/httpclient/impl/HttpConnectorImpl.java
+++ b/connect/http-client/src/main/java/org/cibseven/connect/httpclient/impl/HttpConnectorImpl.java
@@ -16,7 +16,7 @@
  */
 package org.cibseven.connect.httpclient.impl;
 
-import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.cibseven.connect.httpclient.HttpConnector;
 import org.cibseven.connect.httpclient.HttpRequest;
 import org.cibseven.connect.httpclient.HttpResponse;
@@ -35,7 +35,7 @@ public class HttpConnectorImpl extends AbstractHttpConnector<HttpRequest, HttpRe
     return new HttpRequestImpl(this);
   }
 
-  protected HttpResponse createResponse(CloseableHttpResponse response) {
+  protected HttpResponse createResponse(ClassicHttpResponse response) {
     return new HttpResponseImpl(response);
   }
 

--- a/connect/http-client/src/main/java/org/cibseven/connect/httpclient/impl/HttpConnectorLogger.java
+++ b/connect/http-client/src/main/java/org/cibseven/connect/httpclient/impl/HttpConnectorLogger.java
@@ -28,7 +28,6 @@ public class HttpConnectorLogger extends ConnectLogger {
 
   public void ignoreHeader(String field, String value) {
     logInfo("002", "Ignoring header with name '{}' and value '{}'", field, value);
-
   }
 
   public void payloadIgnoredForHttpMethod(String method) {
@@ -60,7 +59,7 @@ public class HttpConnectorLogger extends ConnectLogger {
   }
 
   public ConnectorRequestException httpRequestError(int statusCode , String connectorResponse) {
-    return new ConnectorRequestException(exceptionMessage("010", "HTTP request failed with Status Code: {} ," 
+    return new ConnectorRequestException(exceptionMessage("010", "HTTP request failed with Status Code: {} ,"
         + " Response: {}", statusCode, connectorResponse));
   }
 

--- a/connect/http-client/src/main/java/org/cibseven/connect/httpclient/impl/HttpLogger.java
+++ b/connect/http-client/src/main/java/org/cibseven/connect/httpclient/impl/HttpLogger.java
@@ -22,5 +22,5 @@ public abstract class HttpLogger extends BaseLogger {
 
   public static final String PROJECT_CODE = "HTCL";
 
-  public static HttpConnectorLogger HTTP_LOGGER = createLogger(HttpConnectorLogger.class, PROJECT_CODE, "org.cibseven.bpm.connect.httpclient.connector", "02");
+  public static final HttpConnectorLogger HTTP_LOGGER = createLogger(HttpConnectorLogger.class, PROJECT_CODE, "org.cibseven.bpm.connect.httpclient.connector", "02");
 }

--- a/connect/http-client/src/main/java/org/cibseven/connect/httpclient/impl/HttpRequestInvocation.java
+++ b/connect/http-client/src/main/java/org/cibseven/connect/httpclient/impl/HttpRequestInvocation.java
@@ -18,17 +18,17 @@ package org.cibseven.connect.httpclient.impl;
 
 import java.util.List;
 
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.cibseven.connect.spi.ConnectorRequest;
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
 import org.cibseven.connect.impl.AbstractRequestInvocation;
+import org.cibseven.connect.spi.ConnectorRequest;
 import org.cibseven.connect.spi.ConnectorRequestInterceptor;
 
-public class HttpRequestInvocation  extends AbstractRequestInvocation<HttpRequestBase> {
+public class HttpRequestInvocation extends AbstractRequestInvocation<BasicClassicHttpRequest> {
 
   protected HttpClient client;
 
-  public HttpRequestInvocation(HttpRequestBase target, ConnectorRequest<?> request, List<ConnectorRequestInterceptor> interceptorChain, HttpClient client) {
+  public HttpRequestInvocation(BasicClassicHttpRequest target, ConnectorRequest<?> request, List<ConnectorRequestInterceptor> interceptorChain, HttpClient client) {
     super(target, request, interceptorChain);
     this.client = client;
   }

--- a/connect/http-client/src/main/java/org/cibseven/connect/httpclient/impl/HttpResponseImpl.java
+++ b/connect/http-client/src/main/java/org/cibseven/connect/httpclient/impl/HttpResponseImpl.java
@@ -21,19 +21,19 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.http.Header;
-import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.Header;
+import org.cibseven.commons.utils.IoUtil;
 import org.cibseven.connect.httpclient.HttpResponse;
 import org.cibseven.connect.impl.AbstractCloseableConnectorResponse;
-import org.cibseven.commons.utils.IoUtil;
 
 public class HttpResponseImpl extends AbstractCloseableConnectorResponse implements HttpResponse {
 
-  private final HttpConnectorLogger LOG = HttpLogger.HTTP_LOGGER;
+  private static final HttpConnectorLogger LOG = HttpLogger.HTTP_LOGGER;
 
-  protected CloseableHttpResponse httpResponse;
+  protected ClassicHttpResponse httpResponse;
 
-  public HttpResponseImpl(CloseableHttpResponse httpResponse) {
+  public HttpResponseImpl(ClassicHttpResponse httpResponse) {
     this.httpResponse = httpResponse;
   }
 
@@ -53,16 +53,13 @@ public class HttpResponseImpl extends AbstractCloseableConnectorResponse impleme
     Map<String, String> headers = getHeaders();
     if (headers != null) {
       return headers.get(field);
-    }
-    else {
+    } else {
       return null;
     }
   }
 
   protected void collectResponseParameters(Map<String, Object> responseParameters) {
-    if (httpResponse.getStatusLine() != null) {
-      responseParameters.put(PARAM_NAME_STATUS_CODE, httpResponse.getStatusLine().getStatusCode());
-    }
+    responseParameters.put(PARAM_NAME_STATUS_CODE, httpResponse.getCode());
     collectResponseHeaders();
 
     if (httpResponse.getEntity() != null) {
@@ -78,8 +75,8 @@ public class HttpResponseImpl extends AbstractCloseableConnectorResponse impleme
   }
 
   protected void collectResponseHeaders() {
-    Map<String, String> headers = new HashMap<String, String>();
-    for (Header header : httpResponse.getAllHeaders()) {
+    Map<String, String> headers = new HashMap<>();
+    for (Header header : httpResponse.getHeaders()) {
       headers.put(header.getName(), header.getValue());
     }
     responseParameters.put(PARAM_NAME_RESPONSE_HEADERS, headers);

--- a/connect/http-client/src/main/java/org/cibseven/connect/httpclient/impl/RequestConfigOption.java
+++ b/connect/http-client/src/main/java/org/cibseven/connect/httpclient/impl/RequestConfigOption.java
@@ -16,12 +16,12 @@
  */
 package org.cibseven.connect.httpclient.impl;
 
-import java.net.InetAddress;
 import java.util.Collection;
 import java.util.function.BiConsumer;
 
-import org.apache.http.HttpHost;
-import org.apache.http.client.config.RequestConfig.Builder;
+import org.apache.hc.client5.http.config.RequestConfig.Builder;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.util.Timeout;
 
 public enum RequestConfigOption {
 
@@ -29,43 +29,37 @@ public enum RequestConfigOption {
       (builder, value) -> builder.setAuthenticationEnabled((boolean) value)),
   CIRCULAR_REDIRECTS_ALLOWED("circular-redirects-allowed",
       (builder, value) -> builder.setCircularRedirectsAllowed((boolean) value)),
-  CONNECTION_TIMEOUT("connection-timeout",
-      (builder, value) -> builder.setConnectTimeout((int) value)),
+  CONNECT_TIMEOUT("connect-timeout",
+      (builder, value) -> builder.setConnectTimeout((Timeout) value)),
+  CONNECTION_KEEP_ALIVE("connection-keep-alive",
+      (builder, value) -> builder.setConnectionKeepAlive((Timeout) value)),
   CONNECTION_REQUEST_TIMEOUT("connection-request-timeout",
-      (builder, value) -> builder.setConnectionRequestTimeout((int) value)),
+      (builder, value) -> builder.setConnectionRequestTimeout((Timeout) value)),
   CONTENT_COMPRESSION_ENABLED("content-compression-enabled",
       (builder, value) -> builder.setContentCompressionEnabled((boolean) value)),
   COOKIE_SPEC("cookie-spec",
       (builder, value) -> builder.setCookieSpec((String) value)),
-  DECOMPRESSION_ENABLED("decompression-enabled",
-      (builder, value) -> builder.setDecompressionEnabled((boolean) value)),
   EXPECT_CONTINUE_ENABLED("expect-continue-enabled",
       (builder, value) -> builder.setExpectContinueEnabled((boolean) value)),
-  LOCAL_ADDRESS("local-address",
-      (builder, value) -> builder.setLocalAddress((InetAddress) value)),
+  HARD_CANCELLATION_ENABLED("hard-cancellation-enabled",
+      (builder, value) -> builder.setHardCancellationEnabled((boolean) value)),
   MAX_REDIRECTS("max-redirects",
       (builder, value) -> builder.setMaxRedirects((int) value)),
-  NORMALIZE_URI("normalize-uri",
-      (builder, value) -> builder.setNormalizeUri((boolean) value)),
   PROXY("proxy",
       (builder, value) -> builder.setProxy((HttpHost) value)),
   PROXY_PREFERRED_AUTH_SCHEMES("proxy-preferred-auth-scheme",
       (builder, value) -> builder.setProxyPreferredAuthSchemes((Collection<String>) value)),
-  REDIRECTS_ENABLED("relative-redirects-allowed",
+  REDIRECTS_ENABLED("redirects-enabled",
       (builder, value) -> builder.setRedirectsEnabled((boolean) value)),
-  RELATIVE_REDIRECTS_ALLOWED("relative-redirects-allowed",
-      (builder, value) -> builder.setRelativeRedirectsAllowed((boolean) value)),
-  SOCKET_TIMEOUT("socket-timeout",
-      (builder, value) -> builder.setSocketTimeout((int) value)),
-  STALE_CONNECTION_CHECK_ENABLED("stale-connection-check-enabled",
-      (builder, value) -> builder.setStaleConnectionCheckEnabled((boolean) value)),
+  RESPONSE_TIMEOUT("response-timeout",
+      (builder, value) -> builder.setResponseTimeout((Timeout) value)),
   TARGET_PREFERRED_AUTH_SCHEMES("target-preferred-auth-schemes",
       (builder, value) -> builder.setTargetPreferredAuthSchemes((Collection<String>) value));
 
-  private String name;
-  private BiConsumer<Builder, Object> consumer;
+  private final String name;
+  private final BiConsumer<Builder, Object> consumer;
 
-  private RequestConfigOption(String name, BiConsumer<Builder, Object> consumer) {
+  RequestConfigOption(String name, BiConsumer<Builder, Object> consumer) {
     this.name = name;
     this.consumer = consumer;
   }
@@ -75,7 +69,7 @@ public enum RequestConfigOption {
   }
 
   public void apply(Builder configBuilder, Object value) {
-    this.consumer.accept(configBuilder, value);
+    consumer.accept(configBuilder, value);
   }
 
 }

--- a/connect/http-client/src/main/java/org/cibseven/connect/httpclient/impl/util/ParseUtil.java
+++ b/connect/http-client/src/main/java/org/cibseven/connect/httpclient/impl/util/ParseUtil.java
@@ -18,14 +18,19 @@ package org.cibseven.connect.httpclient.impl.util;
 
 import java.util.Map;
 
-import org.apache.http.client.config.RequestConfig.Builder;
-import org.cibseven.connect.httpclient.impl.RequestConfigOption;
-import org.cibseven.connect.httpclient.impl.HttpConnectorLogger;
+import org.apache.hc.client5.http.config.RequestConfig.Builder;
 import org.cibseven.connect.httpclient.impl.HttpLogger;
+import org.cibseven.connect.httpclient.impl.HttpConnectorLogger;
+import org.cibseven.connect.httpclient.impl.RequestConfigOption;
+
 
 public class ParseUtil {
 
-  protected static HttpConnectorLogger LOG = HttpLogger.HTTP_LOGGER;
+  private static final HttpConnectorLogger LOG = HttpLogger.HTTP_LOGGER;
+
+  private ParseUtil() {
+    /* hidden */
+  }
 
   public static void parseConfigOptions(Map<String, Object> configOptions, Builder configBuilder) {
     for (RequestConfigOption option : RequestConfigOption.values()) {

--- a/connect/http-client/src/test/java/org/cibseven/connect/httpclient/HttpConnectorSystemPropertiesTest.java
+++ b/connect/http-client/src/test/java/org/cibseven/connect/httpclient/HttpConnectorSystemPropertiesTest.java
@@ -16,20 +16,24 @@
  */
 package org.cibseven.connect.httpclient;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.http.protocol.HTTP;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.apache.hc.core5.http.HttpHeaders;
 import org.cibseven.connect.httpclient.impl.HttpConnectorImpl;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
 
 /**
  * Since Apache HTTP client makes it extremely hard to test the proper configuration
@@ -44,13 +48,13 @@ public class HttpConnectorSystemPropertiesTest {
 
   @Rule
   public WireMockRule wireMockRule = new WireMockRule(
-      WireMockConfiguration.wireMockConfig().port(PORT));
+    WireMockConfiguration.wireMockConfig().port(PORT));
 
   protected Set<String> updatedSystemProperties;
 
   @Before
   public void setUp() {
-    updatedSystemProperties = new HashSet<String>();
+    updatedSystemProperties = new HashSet<>();
     wireMockRule.stubFor(get(urlEqualTo("/")).willReturn(aResponse().withStatus(200)));
   }
 
@@ -65,8 +69,7 @@ public class HttpConnectorSystemPropertiesTest {
     if (!System.getProperties().containsKey(property)) {
       updatedSystemProperties.add(property);
       System.setProperty(property, value);
-    }
-    else {
+    } else {
       throw new RuntimeException("Cannot perform test: System property "
           + property + " is already set. Will not attempt to overwrite this property.");
     }
@@ -83,7 +86,6 @@ public class HttpConnectorSystemPropertiesTest {
     customConnector.createRequest().url("http://localhost:" + PORT).get().execute();
 
     // then
-    verify(getRequestedFor(urlEqualTo("/")).withHeader(HTTP.USER_AGENT, equalTo("foo")));
-
+    verify(getRequestedFor(urlEqualTo("/")).withHeader(HttpHeaders.USER_AGENT, equalTo("foo")));
   }
 }

--- a/connect/http-client/src/test/java/org/cibseven/connect/httpclient/HttpConnectorTest.java
+++ b/connect/http-client/src/test/java/org/cibseven/connect/httpclient/HttpConnectorTest.java
@@ -21,16 +21,16 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 
-import org.apache.http.Header;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpOptions;
-import org.apache.http.client.methods.HttpPatch;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.client.methods.HttpTrace;
+import org.apache.hc.client5.http.classic.methods.HttpDelete;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpHead;
+import org.apache.hc.client5.http.classic.methods.HttpOptions;
+import org.apache.hc.client5.http.classic.methods.HttpPatch;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpPut;
+import org.apache.hc.client5.http.classic.methods.HttpTrace;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
 import org.cibseven.commons.utils.IoUtil;
 import org.cibseven.connect.ConnectorRequestException;
 import org.cibseven.connect.Connectors;
@@ -133,10 +133,10 @@ public class HttpConnectorTest {
   }
 
   @Test
-  public void shouldSetUrlOnHttpRequest() {
+  public void shouldSetUrlOnHttpRequest() throws Exception {
     connector.createRequest().url(EXAMPLE_URL).get().execute();
     HttpGet request = interceptor.getTarget();
-    assertThat(request.getURI().toASCIIString()).isEqualTo(EXAMPLE_URL);
+    assertThat(request.getUri().toASCIIString()).isEqualTo(EXAMPLE_URL);
   }
 
   @Test
@@ -153,7 +153,7 @@ public class HttpConnectorTest {
   public void shouldSetHeadersOnHttpRequest() {
     connector.createRequest().url(EXAMPLE_URL).header("foo", "bar").header("hello", "world").get().execute();
     HttpGet request = interceptor.getTarget();
-    Header[] headers = request.getAllHeaders();
+    Header[] headers = request.getHeaders();
     assertThat(headers).hasSize(2);
   }
 
@@ -174,12 +174,12 @@ public class HttpConnectorTest {
     assertThat(contentLength).isEqualTo(EXAMPLE_PAYLOAD.length());
   }
 
-  protected void verifyHttpRequest(Class<? extends HttpRequestBase> requestClass) {
+  protected void verifyHttpRequest(Class<? extends BasicClassicHttpRequest> requestClass) {
     Object target = interceptor.getTarget();
     assertThat(target).isInstanceOf(requestClass);
 
     HttpRequest request = interceptor.getRequest();
-    HttpRequestBase requestBase = (HttpRequestBase) target;
+    BasicClassicHttpRequest requestBase = (BasicClassicHttpRequest) target;
     assertThat(requestBase.getMethod()).isEqualTo(request.getMethod());
   }
 

--- a/connect/http-client/src/test/java/org/cibseven/connect/httpclient/HttpRequestConfigTest.java
+++ b/connect/http-client/src/test/java/org/cibseven/connect/httpclient/HttpRequestConfigTest.java
@@ -16,48 +16,41 @@
  */
 package org.cibseven.connect.httpclient;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.cibseven.connect.httpclient.impl.RequestConfigOption.AUTHENTICATION_ENABLED;
-import static org.cibseven.connect.httpclient.impl.RequestConfigOption.CIRCULAR_REDIRECTS_ALLOWED;
-import static org.cibseven.connect.httpclient.impl.RequestConfigOption.CONNECTION_REQUEST_TIMEOUT;
-import static org.cibseven.connect.httpclient.impl.RequestConfigOption.CONNECTION_TIMEOUT;
-import static org.cibseven.connect.httpclient.impl.RequestConfigOption.CONTENT_COMPRESSION_ENABLED;
-import static org.cibseven.connect.httpclient.impl.RequestConfigOption.COOKIE_SPEC;
-import static org.cibseven.connect.httpclient.impl.RequestConfigOption.DECOMPRESSION_ENABLED;
-import static org.cibseven.connect.httpclient.impl.RequestConfigOption.EXPECT_CONTINUE_ENABLED;
-import static org.cibseven.connect.httpclient.impl.RequestConfigOption.LOCAL_ADDRESS;
-import static org.cibseven.connect.httpclient.impl.RequestConfigOption.MAX_REDIRECTS;
-import static org.cibseven.connect.httpclient.impl.RequestConfigOption.NORMALIZE_URI;
-import static org.cibseven.connect.httpclient.impl.RequestConfigOption.PROXY;
-import static org.cibseven.connect.httpclient.impl.RequestConfigOption.PROXY_PREFERRED_AUTH_SCHEMES;
-import static org.cibseven.connect.httpclient.impl.RequestConfigOption.REDIRECTS_ENABLED;
-import static org.cibseven.connect.httpclient.impl.RequestConfigOption.RELATIVE_REDIRECTS_ALLOWED;
-import static org.cibseven.connect.httpclient.impl.RequestConfigOption.SOCKET_TIMEOUT;
-import static org.cibseven.connect.httpclient.impl.RequestConfigOption.STALE_CONNECTION_CHECK_ENABLED;
-import static org.cibseven.connect.httpclient.impl.RequestConfigOption.TARGET_PREFERRED_AUTH_SCHEMES;
+import static org.junit.Assert.fail;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
+import java.net.SocketTimeoutException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
-import org.apache.http.HttpHost;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.config.RequestConfig.Builder;
-import org.apache.http.conn.ConnectTimeoutException;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.util.Timeout;
 import org.cibseven.connect.ConnectorRequestException;
 import org.cibseven.connect.httpclient.impl.HttpConnectorImpl;
+import org.cibseven.connect.httpclient.impl.RequestConfigOption;
 import org.cibseven.connect.httpclient.impl.util.ParseUtil;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.internal.util.reflection.Whitebox;
 
 public class HttpRequestConfigTest {
 
   public static final String EXAMPLE_URL = "http://camunda.org/example";
-  public static final String EXAMPLE_CONTENT_TYPE = "application/json";
-  public static final String EXAMPLE_PAYLOAD = "camunda";
+
+  public static final int PORT = 51234;
+
+  @Rule
+  public WireMockRule wireMockRule = new WireMockRule(
+          WireMockConfiguration.wireMockConfig().port(PORT));
 
   protected HttpConnector connector;
 
@@ -70,10 +63,10 @@ public class HttpRequestConfigTest {
   public void shouldParseAuthenticationEnabled() {
     // given
     HttpRequest request = connector.createRequest()
-        .configOption(AUTHENTICATION_ENABLED.getName(), false);
+        .configOption(RequestConfigOption.AUTHENTICATION_ENABLED.getName(), false);
     Map<String, Object> configOptions = request.getConfigOptions();
 
-    Builder configBuilder = RequestConfig.custom();
+    RequestConfig.Builder configBuilder = RequestConfig.custom();
     ParseUtil.parseConfigOptions(configOptions, configBuilder);
 
     // when
@@ -87,10 +80,10 @@ public class HttpRequestConfigTest {
   public void shouldParseCircularRedirectsAllowed() {
     // given
     HttpRequest request = connector.createRequest()
-        .configOption(CIRCULAR_REDIRECTS_ALLOWED.getName(), true);
+        .configOption(RequestConfigOption.CIRCULAR_REDIRECTS_ALLOWED.getName(), true);
     Map<String, Object> configOptions = request.getConfigOptions();
 
-    Builder configBuilder = RequestConfig.custom();
+    RequestConfig.Builder configBuilder = RequestConfig.custom();
     ParseUtil.parseConfigOptions(configOptions, configBuilder);
 
     // when
@@ -101,47 +94,47 @@ public class HttpRequestConfigTest {
   }
 
   @Test
-  public void shouldParseConnectionTimeout() {
+  public void shouldParseConnectTimeout() {
     // given
     HttpRequest request = connector.createRequest()
-        .configOption(CONNECTION_TIMEOUT.getName(), -2);
+        .configOption(RequestConfigOption.CONNECT_TIMEOUT.getName(), Timeout.ofSeconds(10));
     Map<String, Object> configOptions = request.getConfigOptions();
 
-    Builder configBuilder = RequestConfig.custom();
+    RequestConfig.Builder configBuilder = RequestConfig.custom();
     ParseUtil.parseConfigOptions(configOptions, configBuilder);
 
     // when
     RequestConfig config = configBuilder.build();
 
     // then
-    assertThat(config.getConnectTimeout()).isEqualTo(-2);
+    assertThat(config.getConnectTimeout()).isEqualTo(Timeout.ofSeconds(10));
   }
 
   @Test
   public void shouldParseConnectionRequestTimeout() {
     // given
     HttpRequest request = connector.createRequest()
-        .configOption(CONNECTION_REQUEST_TIMEOUT.getName(), -2);
+        .configOption(RequestConfigOption.CONNECTION_REQUEST_TIMEOUT.getName(), Timeout.ofSeconds(10));
     Map<String, Object> configOptions = request.getConfigOptions();
 
-    Builder configBuilder = RequestConfig.custom();
+    RequestConfig.Builder configBuilder = RequestConfig.custom();
     ParseUtil.parseConfigOptions(configOptions, configBuilder);
 
     // when
     RequestConfig config = configBuilder.build();
 
     // then
-    assertThat(config.getConnectionRequestTimeout()).isEqualTo(-2);
+    assertThat(config.getConnectionRequestTimeout()).isEqualTo(Timeout.ofSeconds(10));
   }
 
   @Test
   public void shouldParseContentCompressionEnabled() {
     // given
     HttpRequest request = connector.createRequest()
-        .configOption(CONTENT_COMPRESSION_ENABLED.getName(), false);
+        .configOption(RequestConfigOption.CONTENT_COMPRESSION_ENABLED.getName(), false);
     Map<String, Object> configOptions = request.getConfigOptions();
 
-    Builder configBuilder = RequestConfig.custom();
+    RequestConfig.Builder configBuilder = RequestConfig.custom();
     ParseUtil.parseConfigOptions(configOptions, configBuilder);
 
     // when
@@ -155,10 +148,10 @@ public class HttpRequestConfigTest {
   public void shouldParseCookieSpec() {
     // given
     HttpRequest request = connector.createRequest()
-        .configOption(COOKIE_SPEC.getName(), "test");
+        .configOption(RequestConfigOption.COOKIE_SPEC.getName(), "test");
     Map<String, Object> configOptions = request.getConfigOptions();
 
-    Builder configBuilder = RequestConfig.custom();
+    RequestConfig.Builder configBuilder = RequestConfig.custom();
     ParseUtil.parseConfigOptions(configOptions, configBuilder);
 
     // when
@@ -169,65 +162,13 @@ public class HttpRequestConfigTest {
   }
 
   @Test
-  public void shouldParseDecompressionEnabled() {
-    // given
-    HttpRequest request = connector.createRequest()
-        .configOption(DECOMPRESSION_ENABLED.getName(), false);
-    Map<String, Object> configOptions = request.getConfigOptions();
-
-    Builder configBuilder = RequestConfig.custom();
-    ParseUtil.parseConfigOptions(configOptions, configBuilder);
-
-    // when
-    RequestConfig config = configBuilder.build();
-
-    // then
-    assertThat(config.isDecompressionEnabled()).isFalse();
-  }
-
-  @Test
-  public void shouldParseExpectContinueEnabled() {
-    // given
-    HttpRequest request = connector.createRequest()
-        .configOption(EXPECT_CONTINUE_ENABLED.getName(), true);
-    Map<String, Object> configOptions = request.getConfigOptions();
-
-    Builder configBuilder = RequestConfig.custom();
-    ParseUtil.parseConfigOptions(configOptions, configBuilder);
-
-    // when
-    RequestConfig config = configBuilder.build();
-
-    // then
-    assertThat(config.isExpectContinueEnabled()).isTrue();
-  }
-
-  @Test
-  public void shouldParseLocalAddress() throws UnknownHostException {
-    // given
-    InetAddress testAddress = InetAddress.getByName("127.0.0.1");
-    HttpRequest request = connector.createRequest()
-        .configOption(LOCAL_ADDRESS.getName(), testAddress);
-    Map<String, Object> configOptions = request.getConfigOptions();
-
-    Builder configBuilder = RequestConfig.custom();
-    ParseUtil.parseConfigOptions(configOptions, configBuilder);
-
-    // when
-    RequestConfig config = configBuilder.build();
-
-    // then
-    assertThat(config.getLocalAddress()).isEqualTo(testAddress);
-  }
-
-  @Test
   public void shouldParseMaxRedirects() {
     // given
     HttpRequest request = connector.createRequest()
-        .configOption(MAX_REDIRECTS.getName(), -2);
+        .configOption(RequestConfigOption.MAX_REDIRECTS.getName(), -2);
     Map<String, Object> configOptions = request.getConfigOptions();
 
-    Builder configBuilder = RequestConfig.custom();
+    RequestConfig.Builder configBuilder = RequestConfig.custom();
     ParseUtil.parseConfigOptions(configOptions, configBuilder);
 
     // when
@@ -238,31 +179,14 @@ public class HttpRequestConfigTest {
   }
 
   @Test
-  public void shouldParseNormalizeUri() {
-    // given
-    HttpRequest request = connector.createRequest()
-        .configOption(NORMALIZE_URI.getName(), false);
-    Map<String, Object> configOptions = request.getConfigOptions();
-
-    Builder configBuilder = RequestConfig.custom();
-    ParseUtil.parseConfigOptions(configOptions, configBuilder);
-
-    // when
-    RequestConfig config = configBuilder.build();
-
-    // then
-    assertThat(config.isNormalizeUri()).isFalse();
-  }
-
-  @Test
   public void shouldParseProxy() {
     // given
     HttpHost testHost = new HttpHost("test");
     HttpRequest request = connector.createRequest()
-        .configOption(PROXY.getName(), testHost);
+        .configOption(RequestConfigOption.PROXY.getName(), testHost);
     Map<String, Object> configOptions = request.getConfigOptions();
 
-    Builder configBuilder = RequestConfig.custom();
+    RequestConfig.Builder configBuilder = RequestConfig.custom();
     ParseUtil.parseConfigOptions(configOptions, configBuilder);
 
     // when
@@ -275,12 +199,12 @@ public class HttpRequestConfigTest {
   @Test
   public void shouldParseProxyPreferredAuthSchemes() {
     // given
-    ArrayList<String> testArray = new ArrayList<String>();
+    ArrayList<String> testArray = new ArrayList<>();
     HttpRequest request = connector.createRequest()
-        .configOption(PROXY_PREFERRED_AUTH_SCHEMES.getName(), testArray);
+        .configOption(RequestConfigOption.PROXY_PREFERRED_AUTH_SCHEMES.getName(), testArray);
     Map<String, Object> configOptions = request.getConfigOptions();
 
-    Builder configBuilder = RequestConfig.custom();
+    RequestConfig.Builder configBuilder = RequestConfig.custom();
     ParseUtil.parseConfigOptions(configOptions, configBuilder);
 
     // when
@@ -294,10 +218,10 @@ public class HttpRequestConfigTest {
   public void shouldParseRedirectsEnabled() {
     // given
     HttpRequest request = connector.createRequest()
-        .configOption(REDIRECTS_ENABLED.getName(), false);
+        .configOption(RequestConfigOption.REDIRECTS_ENABLED.getName(), false);
     Map<String, Object> configOptions = request.getConfigOptions();
 
-    Builder configBuilder = RequestConfig.custom();
+    RequestConfig.Builder configBuilder = RequestConfig.custom();
     ParseUtil.parseConfigOptions(configOptions, configBuilder);
 
     // when
@@ -308,68 +232,14 @@ public class HttpRequestConfigTest {
   }
 
   @Test
-  public void shouldParseRelativeRedirectsAllowed() {
-    // given
-    HttpRequest request = connector.createRequest()
-        .configOption(RELATIVE_REDIRECTS_ALLOWED.getName(), false);
-    Map<String, Object> configOptions = request.getConfigOptions();
-
-    Builder configBuilder = RequestConfig.custom();
-    ParseUtil.parseConfigOptions(configOptions, configBuilder);
-
-    // when
-    RequestConfig config = configBuilder.build();
-
-    // then
-    assertThat(config.isRelativeRedirectsAllowed()).isFalse();
-  }
-
-
-  @Test
-  public void shouldParseSocketTimeout() {
-    // given
-    HttpRequest request = connector.createRequest()
-        .configOption(SOCKET_TIMEOUT.getName(), -2);
-    Map<String, Object> configOptions = request.getConfigOptions();
-
-    Builder configBuilder = RequestConfig.custom();
-    ParseUtil.parseConfigOptions(configOptions, configBuilder);
-
-    // when
-    RequestConfig config = configBuilder.build();
-
-    // then
-    assertThat(config.getSocketTimeout()).isEqualTo(-2);
-  }
-
-
-  @Test
-  public void shouldParseStaleConnectionCheckEnabled() {
-    // given
-    HttpRequest request = connector.createRequest()
-        .configOption(STALE_CONNECTION_CHECK_ENABLED.getName(), true);
-    Map<String, Object> configOptions = request.getConfigOptions();
-
-    Builder configBuilder = RequestConfig.custom();
-    ParseUtil.parseConfigOptions(configOptions, configBuilder);
-
-    // when
-    RequestConfig config = configBuilder.build();
-
-    // then
-    assertThat(config.isStaleConnectionCheckEnabled()).isTrue();
-  }
-
-
-  @Test
   public void shouldParseTargetPreferredAuthSchemes() {
     // given
-    ArrayList<String> testArray = new ArrayList<String>();
+    List<String> testArray = new ArrayList<>();
     HttpRequest request = connector.createRequest()
-        .configOption(TARGET_PREFERRED_AUTH_SCHEMES.getName(), testArray);
+        .configOption(RequestConfigOption.TARGET_PREFERRED_AUTH_SCHEMES.getName(), testArray);
     Map<String, Object> configOptions = request.getConfigOptions();
 
-    Builder configBuilder = RequestConfig.custom();
+    RequestConfig.Builder configBuilder = RequestConfig.custom();
     ParseUtil.parseConfigOptions(configOptions, configBuilder);
 
     // when
@@ -380,14 +250,82 @@ public class HttpRequestConfigTest {
   }
 
   @Test
+  public void shouldParseConnectionKeepAlive() {
+    // given
+    HttpRequest request = connector.createRequest()
+        .configOption(RequestConfigOption.CONNECTION_KEEP_ALIVE.getName(), Timeout.ofSeconds(10));
+    Map<String, Object> configOptions = request.getConfigOptions();
+
+    RequestConfig.Builder configBuilder = RequestConfig.custom();
+    ParseUtil.parseConfigOptions(configOptions, configBuilder);
+
+    // when
+    RequestConfig config = configBuilder.build();
+
+    // then
+    assertThat(config.getConnectionKeepAlive()).isEqualTo(Timeout.ofSeconds(10));
+  }
+
+  @Test
+  public void shouldParseExpectContinueEnabled() {
+    // given
+    HttpRequest request = connector.createRequest()
+        .configOption(RequestConfigOption.EXPECT_CONTINUE_ENABLED.getName(), true);
+    Map<String, Object> configOptions = request.getConfigOptions();
+
+    RequestConfig.Builder configBuilder = RequestConfig.custom();
+    ParseUtil.parseConfigOptions(configOptions, configBuilder);
+
+    // when
+    RequestConfig config = configBuilder.build();
+
+    // then
+    assertThat(config.isExpectContinueEnabled()).isTrue();
+  }
+
+  @Test
+  public void shouldParseHardCancellationEnabled() {
+    // given
+    HttpRequest request = connector.createRequest()
+        .configOption(RequestConfigOption.HARD_CANCELLATION_ENABLED.getName(), true);
+    Map<String, Object> configOptions = request.getConfigOptions();
+
+    RequestConfig.Builder configBuilder = RequestConfig.custom();
+    ParseUtil.parseConfigOptions(configOptions, configBuilder);
+
+    // when
+    RequestConfig config = configBuilder.build();
+
+    // then
+    assertThat(config.isHardCancellationEnabled()).isTrue();
+  }
+
+  @Test
+  public void shouldParseResponseTimeout() {
+    // given
+    HttpRequest request = connector.createRequest()
+        .configOption(RequestConfigOption.RESPONSE_TIMEOUT.getName(), Timeout.ofSeconds(10));
+    Map<String, Object> configOptions = request.getConfigOptions();
+
+    RequestConfig.Builder configBuilder = RequestConfig.custom();
+    ParseUtil.parseConfigOptions(configOptions, configBuilder);
+
+    // when
+    RequestConfig config = configBuilder.build();
+
+    // then
+    assertThat(config.getResponseTimeout()).isEqualTo(Timeout.ofSeconds(10));
+  }
+
+  @Test
   public void shouldNotChangeDefaultConfig() {
     // given
     HttpClient client = (HttpClient) Whitebox.getInternalState(connector, "httpClient");
     connector.createRequest().url(EXAMPLE_URL).get()
-        .configOption(CONNECTION_TIMEOUT.getName(), -2)
-        .configOption(SOCKET_TIMEOUT.getName(), -2)
-        .configOption(CONNECTION_REQUEST_TIMEOUT.getName(), -2)
-        .configOption(MAX_REDIRECTS.getName(), 0)
+        .configOption(RequestConfigOption.CONNECT_TIMEOUT.getName(), Timeout.ofSeconds(10))
+        .configOption(RequestConfigOption.CONNECTION_REQUEST_TIMEOUT.getName(), Timeout.ofSeconds(10))
+        .configOption(RequestConfigOption.CONNECTION_KEEP_ALIVE.getName(), Timeout.ofSeconds(10))
+        .configOption(RequestConfigOption.MAX_REDIRECTS.getName(), 0)
         .execute();
 
     // when
@@ -395,37 +333,42 @@ public class HttpRequestConfigTest {
 
     // then
     assertThat(config.getMaxRedirects()).isEqualTo(50);
-    assertThat(config.getConnectTimeout()).isEqualTo(-1);
-    assertThat(config.getConnectionRequestTimeout()).isEqualTo(-1);
-    assertThat(config.getSocketTimeout()).isEqualTo(-1);
+    assertThat(config.getConnectTimeout()).isNull();
+    assertThat(config.getConnectionRequestTimeout()).isEqualTo(Timeout.ofMinutes(3));
+    assertThat(config.getConnectionKeepAlive()).isEqualTo(Timeout.ofMinutes(3));
   }
 
   @Test
   public void shouldThrowTimeoutException() {
     try {
+      // given
+      wireMockRule.stubFor(get(urlEqualTo("/")).willReturn(aResponse().withFixedDelay(1000).withStatus(200)));
+
       // when
-      connector.createRequest().url(EXAMPLE_URL).get()
-          .configOption(CONNECTION_TIMEOUT.getName(), 1)
-          .execute();
+      connector.createRequest().url("http://localhost:" + PORT).get()
+              .configOption(RequestConfigOption.RESPONSE_TIMEOUT.getName(), Timeout.ofMilliseconds(100))
+              .execute();
+      fail("No exception thrown");
     } catch (ConnectorRequestException e) {
       // then
       assertThat(e).hasMessageContaining("Unable to execute HTTP request");
-      assertThat(e).hasCauseExactlyInstanceOf(ConnectTimeoutException.class);
+      assertThat(e).hasCauseExactlyInstanceOf(SocketTimeoutException.class);
     }
   }
 
   @Test
-  public void shouldThrowClassCastExceptionStringToInt() {
+  public void shouldThrowClassCastExceptionStringToTimeout() {
     try {
       // when
       connector.createRequest().url(EXAMPLE_URL).get()
-          .configOption(CONNECTION_TIMEOUT.getName(), "-1")
+          .configOption(RequestConfigOption.CONNECT_TIMEOUT.getName(), "0")
           .execute();
+      fail("No exception thrown");
     } catch (ConnectorRequestException e) {
       // then
-      assertThat(e).hasMessageContaining("Invalid value for request configuration option: " + CONNECTION_TIMEOUT.getName());
+      assertThat(e).hasMessageContaining("Invalid value for request configuration option: " + RequestConfigOption.CONNECT_TIMEOUT.getName());
       assertThat(e).hasCauseInstanceOf(ClassCastException.class);
-      assertThat(e.getCause()).hasMessageContaining("java.lang.String cannot be cast to class java.lang.Integer");
+      assertThat(e.getCause()).hasMessageContaining("java.lang.String cannot be cast to class org.apache.hc.core5.util.Timeout");
     }
   }
 
@@ -434,11 +377,12 @@ public class HttpRequestConfigTest {
     try {
       // when
       connector.createRequest().url(EXAMPLE_URL).get()
-          .configOption(AUTHENTICATION_ENABLED.getName(), "true")
+          .configOption(RequestConfigOption.AUTHENTICATION_ENABLED.getName(), "true")
           .execute();
+      fail("No exception thrown");
     } catch (ConnectorRequestException e) {
       // then
-      assertThat(e).hasMessageContaining("Invalid value for request configuration option: " + AUTHENTICATION_ENABLED.getName());
+      assertThat(e).hasMessageContaining("Invalid value for request configuration option: " + RequestConfigOption.AUTHENTICATION_ENABLED.getName());
       assertThat(e).hasCauseInstanceOf(ClassCastException.class);
       assertThat(e.getCause()).hasMessageContaining("java.lang.String cannot be cast to class java.lang.Boolean");
     }
@@ -448,14 +392,14 @@ public class HttpRequestConfigTest {
   public void shouldThrowClassCastExceptionStringToHttpHost() {
     try {
       // when
-      connector.createRequest().url(EXAMPLE_URL).get()
-      .configOption(PROXY.getName(), "proxy")
-      .execute();
+      connector.createRequest().url(EXAMPLE_URL).get().configOption(RequestConfigOption.PROXY.getName(), "proxy")
+          .execute();
+      fail("No exception thrown");
     } catch (ConnectorRequestException e) {
       // then
-      assertThat(e).hasMessageContaining("Invalid value for request configuration option: " + PROXY.getName());
+      assertThat(e).hasMessageContaining("Invalid value for request configuration option: " + RequestConfigOption.PROXY.getName());
       assertThat(e).hasCauseInstanceOf(ClassCastException.class);
-      assertThat(e.getCause()).hasMessageContaining("java.lang.String cannot be cast to class org.apache.http.HttpHost");
+      assertThat(e.getCause()).hasMessageContaining("java.lang.String cannot be cast to class org.apache.hc.core5.http.HttpHost");
     }
   }
 
@@ -464,11 +408,12 @@ public class HttpRequestConfigTest {
     try {
       // when
       connector.createRequest().url(EXAMPLE_URL).get()
-      .configOption(PROXY_PREFERRED_AUTH_SCHEMES.getName(), 0)
-      .execute();
+          .configOption(RequestConfigOption.PROXY_PREFERRED_AUTH_SCHEMES.getName(), 0)
+          .execute();
+      fail("No exception thrown");
     } catch (ConnectorRequestException e) {
       // then
-      assertThat(e).hasMessageContaining("Invalid value for request configuration option: " + PROXY_PREFERRED_AUTH_SCHEMES.getName());
+      assertThat(e).hasMessageContaining("Invalid value for request configuration option: " + RequestConfigOption.PROXY_PREFERRED_AUTH_SCHEMES.getName());
       assertThat(e).hasCauseInstanceOf(ClassCastException.class);
       assertThat(e.getCause()).hasMessageContaining("java.lang.Integer cannot be cast to class java.util.Collection");
     }

--- a/connect/http-client/src/test/java/org/cibseven/connect/httpclient/HttpRequestTest.java
+++ b/connect/http-client/src/test/java/org/cibseven/connect/httpclient/HttpRequestTest.java
@@ -21,14 +21,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpOptions;
-import org.apache.http.client.methods.HttpPatch;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpTrace;
+import org.apache.hc.client5.http.classic.methods.HttpDelete;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpHead;
+import org.apache.hc.client5.http.classic.methods.HttpOptions;
+import org.apache.hc.client5.http.classic.methods.HttpPatch;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpPut;
+import org.apache.hc.client5.http.classic.methods.HttpTrace;
 import org.cibseven.connect.Connectors;
 import org.junit.Before;
 import org.junit.Test;
@@ -148,7 +148,7 @@ public class HttpRequestTest {
 
     request.setRequestParameter("hello", "world");
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("foo", "bar");
     params.put("number", 42);
     request.setRequestParameters(params);
@@ -166,29 +166,29 @@ public class HttpRequestTest {
     HttpRequest request = connector.createRequest()
         .configOption("object-field", value)
         .configOption("int-field", 15)
-        .configOption("long-field", 15l)
+        .configOption("long-field", 15L)
         .configOption("boolean-field", true)
         .configOption("string-field", "string-value");
 
     assertThat(request.getConfigOption("object-field")).isEqualTo(value);
     assertThat(request.getConfigOption("int-field")).isEqualTo(15);
-    assertThat(request.getConfigOption("long-field")).isEqualTo(15l);
+    assertThat(request.getConfigOption("long-field")).isEqualTo(15L);
     assertThat(request.getConfigOption("boolean-field")).isEqualTo(true);
     assertThat(request.getConfigOption("string-field")).isEqualTo("string-value");
   }
 
   @Test
   public void shouldIgnoreConfigWithNullOrEmptyNameOrNullValue() {
-      HttpRequest request = connector.createRequest();
+    HttpRequest request = connector.createRequest();
 
-      request.configOption(null, "test");
-      assertThat(request.getConfigOptions()).isNull();
+    request.configOption(null, "test");
+    assertThat(request.getConfigOptions()).isNull();
 
-      request.configOption("", "test");
-      assertThat(request.getConfigOptions()).isNull();
+    request.configOption("", "test");
+    assertThat(request.getConfigOptions()).isNull();
 
-      request.configOption("test", null);
-      assertThat(request.getConfigOptions()).isNull();
+    request.configOption("test", null);
+    assertThat(request.getConfigOptions()).isNull();
   }
 
   @Test

--- a/connect/http-client/src/test/java/org/cibseven/connect/httpclient/HttpResponseTest.java
+++ b/connect/http-client/src/test/java/org/cibseven/connect/httpclient/HttpResponseTest.java
@@ -39,7 +39,7 @@ public class HttpResponseTest {
 
   @Test
   public void testResponseCode() {
-    testResponse.statusCode(123);
+    testResponse.code(123);
     HttpResponse response = getResponse();
     assertThat(response.getStatusCode()).isEqualTo(123);
   }
@@ -94,7 +94,7 @@ public class HttpResponseTest {
   @Test
   public void testSuccessfulResponseCode() {
     // given
-    testResponse.statusCode(200);
+    testResponse.code(200);
     // when
     HttpResponse response = getResponse();
     // then
@@ -104,7 +104,7 @@ public class HttpResponseTest {
   @Test
   public void testResponseErrorCodeForMalformedRequest() {
     // given
-    testResponse.statusCode(400);
+    testResponse.code(400);
     // when
     HttpResponse response = getResponse();
     // then
@@ -114,7 +114,7 @@ public class HttpResponseTest {
   @Test
   public void testResponseErrorCodeForServerError() {
     // given
-    testResponse.statusCode(500);
+    testResponse.code(500);
     // when
     HttpResponse response = getResponse();
     // then
@@ -124,7 +124,7 @@ public class HttpResponseTest {
   @Test
   public void testServerErrorResponseWithConfigOptionSet() {
     // given
-    testResponse.statusCode(500);
+    testResponse.code(500);
     try {
       // when
       connector.createRequest().configOption("throw-http-error", "TRUE").url("http://camunda.com").get().execute();
@@ -138,7 +138,7 @@ public class HttpResponseTest {
   @Test
   public void testMalformedRequestWithConfigOptionSet() {
     // given
-    testResponse.statusCode(400);
+    testResponse.code(400);
     try {
       // when
       connector.createRequest().configOption("throw-http-error", "TRUE").url("http://camunda.com").get().execute();
@@ -152,7 +152,7 @@ public class HttpResponseTest {
   @Test
   public void testSuccessResponseWithConfigOptionSet() {
     // given
-    testResponse.statusCode(200);
+    testResponse.code(200);
     // when
     connector.createRequest().configOption("throw-http-error", "TRUE").url("http://camunda.com").get().execute();
     // then
@@ -163,7 +163,7 @@ public class HttpResponseTest {
   @Test
   public void testMalformedRequestWithConfigOptionSetToFalse() {
     // given
-    testResponse.statusCode(400);
+    testResponse.code(400);
     // when
     connector.createRequest().configOption("throw-http-error", "FALSE").url("http://camunda.com").get().execute();
     // then

--- a/connect/http-client/src/test/java/org/cibseven/connect/httpclient/TestResponse.java
+++ b/connect/http-client/src/test/java/org/cibseven/connect/httpclient/TestResponse.java
@@ -16,27 +16,27 @@
  */
 package org.cibseven.connect.httpclient;
 
-import java.io.IOException;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.message.BasicHttpResponse;
 
-import org.apache.http.HttpVersion;
-import org.apache.http.ProtocolVersion;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.message.BasicHttpResponse;
 
-public class TestResponse extends BasicHttpResponse implements CloseableHttpResponse {
+public class TestResponse extends BasicHttpResponse implements ClassicHttpResponse {
+
+  private HttpEntity entity;
 
   public TestResponse() {
-    this(HttpVersion.HTTP_1_1, 200, "OK");
+    this(200, "OK");
   }
 
-  public TestResponse(ProtocolVersion ver, int code, String reason) {
-    super(ver, code, reason);
+  public TestResponse(int code, String reason) {
+    super(code, reason);
   }
 
-  public TestResponse statusCode(int statusCode) {
-    setStatusCode(statusCode);
+  public TestResponse code(int code) {
+    setCode(code);
     return this;
   }
 
@@ -52,15 +52,24 @@ public class TestResponse extends BasicHttpResponse implements CloseableHttpResp
   public TestResponse payload(String payload, ContentType contentType) {
     if (payload != null) {
       setEntity(new StringEntity(payload, contentType));
-    }
-    else {
+    } else {
       setEntity(null);
     }
     return this;
   }
 
-  public void close() throws IOException {
-
+  @Override
+  public HttpEntity getEntity() {
+    return entity;
   }
 
+  @Override
+  public void setEntity(HttpEntity entity) {
+    this.entity = entity;
+  }
+
+  @Override
+  public void close() {
+    /* NOP */
+  }
 }

--- a/connect/pom.xml
+++ b/connect/pom.xml
@@ -15,7 +15,6 @@
   <packaging>pom</packaging>
 
   <properties>
-    <commons-codec.version>1.15</commons-codec.version>
     <connect.version.old>7.22.0</connect.version.old>
     <mockito.version>1.9.5</mockito.version>
     <wiremock.version>1.58</wiremock.version>
@@ -37,15 +36,9 @@
     <dependencies>
 
       <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient</artifactId>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
         <version>${version.httpclient}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>commons-codec</groupId>
-        <artifactId>commons-codec</artifactId>
-        <version>${commons-codec.version}</version>
       </dependency>
 
       <dependency>

--- a/connect/soap-http-client/src/main/java/org/cibseven/connect/httpclient/soap/SoapHttpConnector.java
+++ b/connect/soap-http-client/src/main/java/org/cibseven/connect/httpclient/soap/SoapHttpConnector.java
@@ -21,6 +21,6 @@ import org.cibseven.connect.spi.Connector;
 
 public interface SoapHttpConnector extends Connector<SoapHttpRequest> {
 
-  static final String ID = Connectors.SOAP_HTTP_CONNECTOR_ID;
+  String ID = Connectors.SOAP_HTTP_CONNECTOR_ID;
 
 }

--- a/connect/soap-http-client/src/main/java/org/cibseven/connect/httpclient/soap/impl/SoapHttpConnectorImpl.java
+++ b/connect/soap-http-client/src/main/java/org/cibseven/connect/httpclient/soap/impl/SoapHttpConnectorImpl.java
@@ -16,8 +16,8 @@
  */
 package org.cibseven.connect.httpclient.soap.impl;
 
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
 import org.cibseven.connect.httpclient.impl.AbstractHttpConnector;
 import org.cibseven.connect.httpclient.impl.AbstractHttpRequest;
 import org.cibseven.connect.httpclient.soap.SoapHttpConnector;
@@ -26,7 +26,7 @@ import org.cibseven.connect.httpclient.soap.SoapHttpResponse;
 
 public class SoapHttpConnectorImpl extends AbstractHttpConnector<SoapHttpRequest, SoapHttpResponse> implements SoapHttpConnector {
 
-  protected static final SoapHttpConnectorLogger LOG = SoapHttpLogger.SOAP_CONNECTOR_LOGGER;
+  protected static final SoapHttpConnectorLogger LOG = SoapHttpLogger.SOAP_HTTP_CONNECTOR_LOGGER;
 
   public SoapHttpConnectorImpl() {
     super(SoapHttpConnector.ID);
@@ -40,20 +40,20 @@ public class SoapHttpConnectorImpl extends AbstractHttpConnector<SoapHttpRequest
     return new SoapHttpRequestImpl(this);
   }
 
-  protected SoapHttpResponse createResponse(CloseableHttpResponse response) {
+  protected SoapHttpResponse createResponse(ClassicHttpResponse response) {
     return new SoapHttpResponseImpl(response);
   }
 
   @Override
   public SoapHttpResponse execute(SoapHttpRequest request) {
     // always use the POST method
-    ((AbstractHttpRequest) request).post();
+    ((AbstractHttpRequest<?, ?>) request).post();
 
     return super.execute(request);
   }
 
   @Override
-  protected <T extends HttpRequestBase> void applyPayload(T httpRequest, SoapHttpRequest request) {
+  protected <T extends BasicClassicHttpRequest> void applyPayload(T httpRequest, SoapHttpRequest request) {
     // SOAP requires soap envelop body
     if (request.getPayload() == null || request.getPayload().trim().isEmpty()) {
       throw LOG.noPayloadSet();

--- a/connect/soap-http-client/src/main/java/org/cibseven/connect/httpclient/soap/impl/SoapHttpConnectorProviderImpl.java
+++ b/connect/soap-http-client/src/main/java/org/cibseven/connect/httpclient/soap/impl/SoapHttpConnectorProviderImpl.java
@@ -17,9 +17,9 @@
 package org.cibseven.connect.httpclient.soap.impl;
 
 import org.cibseven.connect.httpclient.soap.SoapHttpConnector;
-import org.cibseven.connect.spi.ConnectorProvider;
+import org.cibseven.connect.httpclient.soap.SoapHttpConnectorProvider;
 
-public class SoapHttpConnectorProviderImpl implements ConnectorProvider {
+public class SoapHttpConnectorProviderImpl implements SoapHttpConnectorProvider {
 
   public String getConnectorId() {
     return SoapHttpConnector.ID;

--- a/connect/soap-http-client/src/main/java/org/cibseven/connect/httpclient/soap/impl/SoapHttpLogger.java
+++ b/connect/soap-http-client/src/main/java/org/cibseven/connect/httpclient/soap/impl/SoapHttpLogger.java
@@ -22,6 +22,6 @@ public abstract class SoapHttpLogger extends BaseLogger {
 
   public static final String PROJECT_CODE = "SOAPC";
 
-  public static SoapHttpConnectorLogger SOAP_CONNECTOR_LOGGER = createLogger(SoapHttpConnectorLogger.class, PROJECT_CODE, "org.cibseven.bpm.connect.soap.httpclient.connector", "01");
+  public static final SoapHttpConnectorLogger SOAP_HTTP_CONNECTOR_LOGGER = createLogger(SoapHttpConnectorLogger.class, PROJECT_CODE, "org.cibseven.bpm.connect.soap.httpclient.connector", "01");
 
 }

--- a/connect/soap-http-client/src/main/java/org/cibseven/connect/httpclient/soap/impl/SoapHttpRequestImpl.java
+++ b/connect/soap-http-client/src/main/java/org/cibseven/connect/httpclient/soap/impl/SoapHttpRequestImpl.java
@@ -16,7 +16,7 @@
  */
 package org.cibseven.connect.httpclient.soap.impl;
 
-import org.apache.http.client.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.cibseven.connect.httpclient.impl.AbstractHttpRequest;
 import org.cibseven.connect.httpclient.soap.SoapHttpConnector;
 import org.cibseven.connect.httpclient.soap.SoapHttpRequest;
@@ -24,7 +24,7 @@ import org.cibseven.connect.httpclient.soap.SoapHttpResponse;
 
 public class SoapHttpRequestImpl extends AbstractHttpRequest<SoapHttpRequest, SoapHttpResponse> implements SoapHttpRequest {
 
-  protected static final SoapHttpConnectorLogger LOG = SoapHttpLogger.SOAP_CONNECTOR_LOGGER;
+  protected static final SoapHttpConnectorLogger LOG = SoapHttpLogger.SOAP_HTTP_CONNECTOR_LOGGER;
 
   public SoapHttpRequestImpl(SoapHttpConnector connector) {
     super(connector);

--- a/connect/soap-http-client/src/main/java/org/cibseven/connect/httpclient/soap/impl/SoapHttpResponseImpl.java
+++ b/connect/soap-http-client/src/main/java/org/cibseven/connect/httpclient/soap/impl/SoapHttpResponseImpl.java
@@ -16,13 +16,13 @@
  */
 package org.cibseven.connect.httpclient.soap.impl;
 
-import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.cibseven.connect.httpclient.impl.HttpResponseImpl;
 import org.cibseven.connect.httpclient.soap.SoapHttpResponse;
 
 public class SoapHttpResponseImpl extends HttpResponseImpl implements SoapHttpResponse {
 
-  public SoapHttpResponseImpl(CloseableHttpResponse httpResponse) {
+  public SoapHttpResponseImpl(ClassicHttpResponse httpResponse) {
     super(httpResponse);
   }
 

--- a/connect/soap-http-client/src/test/java/org/cibseven/connect/httpclient/soap/SoapHttpConnectorSystemPropertiesTest.java
+++ b/connect/soap-http-client/src/test/java/org/cibseven/connect/httpclient/soap/SoapHttpConnectorSystemPropertiesTest.java
@@ -14,31 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.cibseven.connect.soap.httpclient;
+package org.cibseven.connect.httpclient.soap;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.http.protocol.HTTP;
-import org.cibseven.connect.httpclient.HttpConnector;
-import org.cibseven.connect.httpclient.impl.HttpConnectorImpl;
-import org.cibseven.connect.httpclient.soap.SoapHttpConnector;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.apache.hc.core5.http.HttpHeaders;
 import org.cibseven.connect.httpclient.soap.impl.SoapHttpConnectorImpl;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
 
 /**
  * Since Apache HTTP client makes it extremely hard to test the proper configuration
@@ -59,7 +54,7 @@ public class SoapHttpConnectorSystemPropertiesTest {
 
   @Before
   public void setUp() {
-    updatedSystemProperties = new HashSet<String>();
+    updatedSystemProperties = new HashSet<>();
     wireMockRule.stubFor(get(urlEqualTo("/")).willReturn(aResponse().withStatus(200)));
   }
 
@@ -74,8 +69,7 @@ public class SoapHttpConnectorSystemPropertiesTest {
     if (!System.getProperties().containsKey(property)) {
       updatedSystemProperties.add(property);
       System.setProperty(property, value);
-    }
-    else {
+    } else {
       throw new RuntimeException("Cannot perform test: System property "
           + property + " is already set. Will not attempt to overwrite this property.");
     }
@@ -92,7 +86,7 @@ public class SoapHttpConnectorSystemPropertiesTest {
     customConnector.createRequest().url("http://localhost:" + PORT).payload("test").execute();
 
     // then
-    verify(postRequestedFor(urlEqualTo("/")).withHeader(HTTP.USER_AGENT, equalTo("foo")));
+    verify(postRequestedFor(urlEqualTo("/")).withHeader(HttpHeaders.USER_AGENT, equalTo("foo")));
 
   }
 }

--- a/connect/soap-http-client/src/test/java/org/cibseven/connect/httpclient/soap/SoapHttpConnectorTest.java
+++ b/connect/soap-http-client/src/test/java/org/cibseven/connect/httpclient/soap/SoapHttpConnectorTest.java
@@ -14,13 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.cibseven.connect.soap.httpclient;
+package org.cibseven.connect.httpclient.soap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.apache.http.client.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.cibseven.connect.Connectors;
-import org.cibseven.connect.httpclient.soap.SoapHttpConnector;
 import org.cibseven.connect.httpclient.soap.impl.SoapHttpConnectorImpl;
 import org.cibseven.connect.impl.DebugRequestInterceptor;
 import org.cibseven.connect.spi.Connector;

--- a/connect/soap-http-client/src/test/java/org/cibseven/connect/httpclient/soap/SoapHttpRequestTest.java
+++ b/connect/soap-http-client/src/test/java/org/cibseven/connect/httpclient/soap/SoapHttpRequestTest.java
@@ -14,13 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.cibseven.connect.soap.httpclient;
+package org.cibseven.connect.httpclient.soap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.cibseven.connect.Connectors;
-import org.cibseven.connect.httpclient.soap.SoapHttpConnector;
-import org.cibseven.connect.httpclient.soap.SoapHttpRequest;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/distro/run/qa/integration-tests/pom.xml
+++ b/distro/run/qa/integration-tests/pom.xml
@@ -80,8 +80,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
       <version>${version.httpclient}</version>
       <scope>test</scope>
     </dependency>

--- a/distro/run/qa/runtime/pom.xml
+++ b/distro/run/qa/runtime/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>cibseven-bpm-run-qa-runtime</artifactId>
   <name>CIB seven - Run - QA - Runtime</name>
   <packaging>jar</packaging>
-  
+
   <properties>
     <run-home>${project.build.directory}/run/cibseven-bpm-run-distro</run-home>
     <example-plugin-home>${project.build.directory}/run/example-plugin</example-plugin-home>
@@ -109,8 +109,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
       <version>${version.httpclient}</version>
       <scope>test</scope>
     </dependency>

--- a/engine-plugins/connect-plugin/src/test/java/org/cibseven/connect/plugin/MockHttpConnectorConfigurator.java
+++ b/engine-plugins/connect-plugin/src/test/java/org/cibseven/connect/plugin/MockHttpConnectorConfigurator.java
@@ -16,13 +16,11 @@
  */
 package org.cibseven.connect.plugin;
 
-import java.io.IOException;
-
-import org.apache.http.HttpVersion;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.message.BasicHttpResponse;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.message.BasicHttpResponse;
 import org.cibseven.connect.httpclient.HttpConnector;
 import org.cibseven.connect.httpclient.impl.HttpResponseImpl;
 import org.cibseven.connect.spi.ConnectorConfigurator;
@@ -59,14 +57,27 @@ public class MockHttpConnectorConfigurator implements ConnectorConfigurator<Http
     return HttpConnector.class;
   }
 
-  static class TestHttpResonse extends BasicHttpResponse implements CloseableHttpResponse {
+  static class TestHttpResonse extends BasicHttpResponse implements ClassicHttpResponse {
+
+    private HttpEntity entity;
 
     public TestHttpResonse() {
-      super(HttpVersion.HTTP_1_1, 200, "OK");
+      super(200, "OK");
     }
 
-    public void close() throws IOException {
-      // no-op
+    @Override
+    public HttpEntity getEntity() {
+      return entity;
+    }
+
+    @Override
+    public void setEntity(HttpEntity entity) {
+      this.entity = entity;
+    }
+
+    @Override
+    public void close() {
+      /* NOP */
     }
   }
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -42,8 +42,7 @@
     <version.xml.jaxb-impl>2.3.6</version.xml.jaxb-impl>
     <version.xml.jaxb-impl4>4.0.5</version.xml.jaxb-impl4>
     <version.jakarta.xml.bind-api>4.0.2</version.jakarta.xml.bind-api>
-    <version.httpclient>4.5.14</version.httpclient>
-    <version.httpclient5>5.3</version.httpclient5>
+    <version.httpclient>5.4.1</version.httpclient>
 
     <version.slf4j>1.7.26</version.slf4j>
     <version.logback>1.2.11</version.logback>

--- a/spring-boot-starter/starter-qa/integration-test-webapp/runtime/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-webapp/runtime/pom.xml
@@ -80,8 +80,8 @@
         </dependency>
 
         <dependency>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient</artifactId>
+          <groupId>org.apache.httpcomponents.client5</groupId>
+          <artifactId>httpclient5</artifactId>
           <version>${version.httpclient}</version>
           <scope>test</scope>
         </dependency>

--- a/spring-boot-starter/starter-security/pom.xml
+++ b/spring-boot-starter/starter-security/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>
       <artifactId>httpclient5</artifactId>
-      <version>${version.httpclient5}</version>
+      <version>${version.httpclient}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Since https://github.com/camunda/camunda-bpm-platform/pull/4569 is likely not going to be merged I'm trying my luck here.

This PR includes:
* HTTP and SOAP connectors based on httpclient 5.x
* Trivial code cleanup

Some details I want to point out:
* Compatibility in usage of httpclient 5 over 4 should be fine thanks to the abstraction. The only thing that really changed are the configuration options - some got removed, some got renamed, some new were added.
* I had to remove some tests due to the config changes (but added new ones as well). Further I had to adapt some tests because they did not test properly to begin with.

I'd be happy to discuss any recommendations or changes. 