### PR TITLE
fix delete tenant group membership

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/tenant/{id}/group-members/{groupId}/delete.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/tenant/{id}/group-members/{groupId}/delete.ftl
@@ -4,8 +4,8 @@
   <@lib.endpointInfo
       id = "deleteGroupMembership"
       tag = "Tenant"
-      summary = "Create Tenant Group Membership"
-      desc = "Creates a membership between a tenant and a group."
+      summary = "Delete Tenant Group Membership"
+      desc = "Deletes a membership between a tenant and a group."
   />
 
   "parameters" : [


### PR DESCRIPTION
REST documentation is wrong for the "delete tenant group membership"

![image (7)](https://github.com/user-attachments/assets/2ee5a4a4-738a-4774-9835-80d9edf9aa95)
