### PR TITLE
chore(config): remove JWT secret configuration from cibseven-webclient.properties

### DIFF
--- a/engine-rest/assembly-jakarta/.gitignore
+++ b/engine-rest/assembly-jakarta/.gitignore
@@ -1,0 +1,1 @@
+src/main/webapp/WEB-INF/classes/cibseven-webclient.properties

--- a/engine-rest/assembly-jakarta/src/main/webapp/WEB-INF/classes/cibseven-webclient.properties
+++ b/engine-rest/assembly-jakarta/src/main/webapp/WEB-INF/classes/cibseven-webclient.properties
@@ -1,1 +1,0 @@
-authentication.jwtSecret=


### PR DESCRIPTION
so that every distribution can have better control over it