### PR TITLE
chore(pom): fixed warning with maven-dependency-plugin multi usage

### DIFF
--- a/distro/run/qa/runtime/pom.xml
+++ b/distro/run/qa/runtime/pom.xml
@@ -182,12 +182,6 @@
                   <excludes>configuration/default.yml,configuration/production.yml</excludes>
                 </configuration>
               </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <executions>
               <execution>
                 <id>copy-plugin</id>
                 <goals>
@@ -302,7 +296,7 @@
     <url>https://github.com/cibseven/cibseven</url>
     <connection>scm:git:git@github.com:cibseven/cibseven.git</connection>
     <developerConnection>scm:git:git@github.com:cibseven/cibseven.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v1.1.0</tag>
   </scm>
 
   <issueManagement>

--- a/distro/run/qa/runtime/pom.xml
+++ b/distro/run/qa/runtime/pom.xml
@@ -296,7 +296,7 @@
     <url>https://github.com/cibseven/cibseven</url>
     <connection>scm:git:git@github.com:cibseven/cibseven.git</connection>
     <developerConnection>scm:git:git@github.com:cibseven/cibseven.git</developerConnection>
-    <tag>v1.1.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <issueManagement>


### PR DESCRIPTION
> [INFO] Scanning for projects...
> [WARNING]
> [WARNING] Some problems were encountered while building the effective model for org.cibseven.bpm.run:cibseven-bpm-run-qa-runtime:jar:1.2.0-SNAPSHOT
> [WARNING] 'profiles.profile[integration-test-run].plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-dependency-plugin @ line 187, column 19
> [WARNING]
> [WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
> [WARNING]
> [WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
> [WARNING]
