### PR TITLE
fix(random): use LC_CTYPE=C for tr

### DIFF
--- a/distro/run/assembly/resources/run.sh
+++ b/distro/run/assembly/resources/run.sh
@@ -35,7 +35,7 @@ webclientProperties="$PARENTDIR/configuration/userlib/cibseven-webclient.propert
 if [ ! -f "$webclientProperties" ]; then
 
   # Generate a 155-character alphanumeric random string
-  RANDOM_STRING=$(tr -dc 'A-Za-z0-9' </dev/urandom | head -c 155)
+  RANDOM_STRING=$(LC_CTYPE=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 155)
 
   # Write the content to the file
   echo "authentication.jwtSecret=$RANDOM_STRING" > "$webclientProperties"

--- a/distro/tomcat/assembly/src/start-cibseven.sh
+++ b/distro/tomcat/assembly/src/start-cibseven.sh
@@ -11,7 +11,7 @@ if [ ! -f "$FILE" ]; then
   # mkdir -p "$(dirname "$FILE")"
 
   # Generate a 155-character alphanumeric random string
-  RANDOM_STRING=$(tr -dc 'A-Za-z0-9' </dev/urandom | head -c 155)
+  RANDOM_STRING=$(LC_CTYPE=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 155)
 
   # Write the content to the file
   echo "authentication.jwtSecret=$RANDOM_STRING" > "$FILE"

--- a/distro/wildfly/assembly/src/start-cibseven.sh
+++ b/distro/wildfly/assembly/src/start-cibseven.sh
@@ -11,7 +11,7 @@ if [ ! -f "$FILE" ]; then
   # mkdir -p "$(dirname "$FILE")"
 
   # Generate a 155-character alphanumeric random string
-  RANDOM_STRING=$(tr -dc 'A-Za-z0-9' </dev/urandom | head -c 155)
+  RANDOM_STRING=$(LC_CTYPE=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 155)
 
   # Write the content to the file
   echo "authentication.jwtSecret=$RANDOM_STRING" > "$FILE"


### PR DESCRIPTION
Solution for "tr: Illegal byte sequence" error encountered during the generation of cibseven-webclient.properties on darwin 