### PR TITLE
fix(tests): add engineRest.path to application-test-changed-rest-context-path.yml

### DIFF
--- a/distro/run/core/src/test/resources/application-test-changed-rest-context-path.yml
+++ b/distro/run/core/src/test/resources/application-test-changed-rest-context-path.yml
@@ -1,1 +1,2 @@
 spring.jersey.application-path: "/rest"
+cibseven.webclient.engineRest.path: "/rest"


### PR DESCRIPTION
- REST endpoints existed at /rest/*
- Authentication filters were applied to /engine-rest/*
- Result: Requests to /rest/* returned 404 NOT_FOUND instead of 401 UNAUTHORIZED

See https://github.com/cibseven/cibseven/actions/workflows/maven.yml

Fix failed tests for cibseven/distro/run/core