### PR TITLE
chore(dependencies) update commons-io to version 2.18.0

### DIFF
--- a/internal-dependencies/pom.xml
+++ b/internal-dependencies/pom.xml
@@ -62,7 +62,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>commons-fileupload</groupId>


### PR DESCRIPTION
Upgrades commons-io to the same version the cibseven-weblient already uses.