### PR TITLE
Fix typo in VariableInstanceDto description in OpenAPI spec

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/cibseven/bpm/engine/rest/dto/runtime/VariableInstanceDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/cibseven/bpm/engine/rest/dto/runtime/VariableInstanceDto.ftl
@@ -53,7 +53,7 @@
     <@lib.property
         name = "batchId"
         type = "string"
-        desc = "The id of the batch that this variable instance belongs to.<"
+        desc = "The id of the batch that this variable instance belongs to."
     />
     
     <@lib.property


### PR DESCRIPTION
Corrected a typo in the `VariableInstanceDto` FreeMarker template where the description for `batchId` contained an erroneous trailing `<` character.
Verified the fix by regenerating the `openapi.json` and checking that the character is removed.
Ran the full build for the `engine-rest-openapi` module to ensure no regressions and that the generated spec remains valid.

---
*PR created automatically by Jules for task [14621201985893246689](https://jules.google.com/task/14621201985893246689) started by @OlegCIB*