### PR TITLE
Upgrade Spring Boot and Tomcat versions

### DIFF
--- a/Jenkinsfile.cib
+++ b/Jenkinsfile.cib
@@ -435,7 +435,7 @@ pipeline {
 
                     withMaven(options: []) {
                         sh """
-                            mvn -T4 -U \
+                            mvn -U \
                                 -DskipTests \
                                 -Pwebapps-integration ${deployment} \
                                 clean deploy

--- a/bom/camunda-bom/pom.xml
+++ b/bom/camunda-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-bom-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/bom/camunda-only-bom/pom.xml
+++ b/bom/camunda-only-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-bom-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/clients/java/client/pom.xml
+++ b/clients/java/client/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-external-task-client-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -13,7 +13,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <modules>

--- a/clients/java/qa/engine-variable-test/pom.xml
+++ b/clients/java/qa/engine-variable-test/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.cibseven.bpm.qa</groupId>
     <artifactId>cibseven-external-task-client-qa</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/clients/java/qa/pom.xml
+++ b/clients/java/qa/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-external-task-client-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <modules>

--- a/commons/bom/pom.xml
+++ b/commons/bom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/commons/logging/pom.xml
+++ b/commons/logging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.commons</groupId>
     <artifactId>cibseven-commons-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-commons-logging</artifactId>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-parent</artifactId>
     <relativePath>../parent</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.cibseven.commons</groupId>

--- a/commons/testing/pom.xml
+++ b/commons/testing/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.commons</groupId>
     <artifactId>cibseven-commons-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-commons-testing</artifactId>

--- a/commons/typed-values/pom.xml
+++ b/commons/typed-values/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/commons/utils/pom.xml
+++ b/commons/utils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.commons</groupId>
     <artifactId>cibseven-commons-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-commons-utils</artifactId>

--- a/connect/bom/pom.xml
+++ b/connect/bom/pom.xml
@@ -6,13 +6,13 @@
   <parent>
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <groupId>org.cibseven.connect</groupId>
   <artifactId>cibseven-connect-bom</artifactId>
-  <version>2.2.0-SNAPSHOT</version>
+  <version>2.2.0-alpha1-SNAPSHOT</version>
   <name>CIB seven - connect - bom</name>
   <packaging>pom</packaging>
 

--- a/connect/connectors-all/pom.xml
+++ b/connect/connectors-all/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.connect</groupId>
     <artifactId>cibseven-connect-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-connect-connectors-all</artifactId>

--- a/connect/core/pom.xml
+++ b/connect/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.connect</groupId>
     <artifactId>cibseven-connect-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-connect-core</artifactId>

--- a/connect/http-client/pom.xml
+++ b/connect/http-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>cibseven-connect-root</artifactId>
     <groupId>org.cibseven.connect</groupId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/connect/pom.xml
+++ b/connect/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-parent</artifactId>
     <relativePath>../parent</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.cibseven.connect</groupId>

--- a/connect/soap-http-client/pom.xml
+++ b/connect/soap-http-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.connect</groupId>
     <artifactId>cibseven-connect-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-connect-soap-http-client</artifactId>

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-parent</artifactId>
     <relativePath>../parent</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-database-settings</artifactId>

--- a/distro/jboss/pom.xml
+++ b/distro/jboss/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
   
   <groupId>org.cibseven.bpm.jboss</groupId>

--- a/distro/jboss/webapp/pom.xml
+++ b/distro/jboss/webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.cibseven.bpm.jboss</groupId>
     <artifactId>cibseven-jboss</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/distro/license-book/pom.xml
+++ b/distro/license-book/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>license-book</artifactId>

--- a/distro/run/assembly/pom.xml
+++ b/distro/run/assembly/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.run</groupId>
     <artifactId>cibseven-bpm-run-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/core/pom.xml
+++ b/distro/run/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.run</groupId>
     <artifactId>cibseven-bpm-run-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/distro/pom.xml
+++ b/distro/run/distro/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.run</groupId>
     <artifactId>cibseven-bpm-run-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/modules/example/pom.xml
+++ b/distro/run/modules/example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.run</groupId>
     <artifactId>cibseven-bpm-run-modules</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-bpm-run-modules-example-invoice</artifactId>

--- a/distro/run/modules/oauth2/pom.xml
+++ b/distro/run/modules/oauth2/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.run</groupId>
     <artifactId>cibseven-bpm-run-modules</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/modules/pom.xml
+++ b/distro/run/modules/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.run</groupId>
     <artifactId>cibseven-bpm-run-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/modules/rest/pom.xml
+++ b/distro/run/modules/rest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.run</groupId>
     <artifactId>cibseven-bpm-run-modules</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/modules/webapps/pom.xml
+++ b/distro/run/modules/webapps/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.run</groupId>
     <artifactId>cibseven-bpm-run-modules</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/pom.xml
+++ b/distro/run/pom.xml
@@ -26,15 +26,6 @@
         <type>pom</type>
       </dependency>
 
-      <!-- Override Tomcat versions from Spring Boot BOM for all Tomcat artifacts -->
-      <dependency>
-        <groupId>org.apache.tomcat</groupId>
-        <artifactId>tomcat-bom</artifactId>
-        <version>${version.tomcat}</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-
       <dependency>
         <groupId>org.graalvm.js</groupId>
         <artifactId>js</artifactId>

--- a/distro/run/pom.xml
+++ b/distro/run/pom.xml
@@ -26,21 +26,13 @@
         <type>pom</type>
       </dependency>
 
-      <!-- Override Tomcat version from Spring Boot BOM -->
+      <!-- Override Tomcat versions from Spring Boot BOM for all Tomcat artifacts -->
       <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-core</artifactId>
+        <groupId>org.apache.tomcat</groupId>
+        <artifactId>tomcat-bom</artifactId>
         <version>${version.tomcat}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-el</artifactId>
-        <version>${version.tomcat}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-websocket</artifactId>
-        <version>${version.tomcat}</version>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
 
       <dependency>

--- a/distro/run/pom.xml
+++ b/distro/run/pom.xml
@@ -15,6 +15,11 @@
   <description>This is the root of CIB seven Run</description>
   <packaging>pom</packaging>
 
+  <properties>
+    <!-- Spring Boot will automatically apply tomcat.version to all Tomcat modules -->
+    <tomcat.version>${version.tomcat}</tomcat.version>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
 

--- a/distro/run/pom.xml
+++ b/distro/run/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>../../database</relativePath>
   </parent>
 

--- a/distro/run/pom.xml
+++ b/distro/run/pom.xml
@@ -15,11 +15,6 @@
   <description>This is the root of CIB seven Run</description>
   <packaging>pom</packaging>
 
-  <properties>
-    <!-- Spring Boot will automatically apply tomcat.version to all Tomcat modules -->
-    <tomcat.version>${version.tomcat}</tomcat.version>
-  </properties>
-
   <dependencyManagement>
     <dependencies>
 
@@ -29,6 +24,23 @@
         <version>${version.spring-boot}</version>
         <scope>import</scope>
         <type>pom</type>
+      </dependency>
+
+      <!-- Override Tomcat version from Spring Boot BOM -->
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-el</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-websocket</artifactId>
+        <version>${version.tomcat}</version>
       </dependency>
 
       <dependency>

--- a/distro/run/qa/example-plugin/pom.xml
+++ b/distro/run/qa/example-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.run</groupId>
     <artifactId>cibseven-bpm-run-qa</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/qa/integration-tests/pom.xml
+++ b/distro/run/qa/integration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.run</groupId>
     <artifactId>cibseven-bpm-run-qa</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/qa/pom.xml
+++ b/distro/run/qa/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.run</groupId>
     <artifactId>cibseven-bpm-run-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/qa/runtime/pom.xml
+++ b/distro/run/qa/runtime/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.run</groupId>
     <artifactId>cibseven-bpm-run-qa</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run4/assembly/pom.xml
+++ b/distro/run4/assembly/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.run</groupId>
     <artifactId>cibseven-bpm-run4-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run4/core/pom.xml
+++ b/distro/run4/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.run</groupId>
     <artifactId>cibseven-bpm-run4-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run4/distro/pom.xml
+++ b/distro/run4/distro/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.run</groupId>
     <artifactId>cibseven-bpm-run4-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run4/modules/example/pom.xml
+++ b/distro/run4/modules/example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.run</groupId>
     <artifactId>cibseven-bpm-run4-modules</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-bpm-run4-modules-example-invoice</artifactId>

--- a/distro/run4/modules/oauth2/pom.xml
+++ b/distro/run4/modules/oauth2/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.run</groupId>
     <artifactId>cibseven-bpm-run4-modules</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run4/modules/pom.xml
+++ b/distro/run4/modules/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.run</groupId>
     <artifactId>cibseven-bpm-run4-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run4/modules/rest/pom.xml
+++ b/distro/run4/modules/rest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.run</groupId>
     <artifactId>cibseven-bpm-run4-modules</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run4/modules/webapps/pom.xml
+++ b/distro/run4/modules/webapps/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.run</groupId>
     <artifactId>cibseven-bpm-run4-modules</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run4/pom.xml
+++ b/distro/run4/pom.xml
@@ -25,6 +25,23 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
+      
+      <!-- Override Tomcat version from Spring Boot BOM -->
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>${version.tomcat.springboot4}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-el</artifactId>
+        <version>${version.tomcat.springboot4}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-websocket</artifactId>
+        <version>${version.tomcat.springboot4}</version>
+      </dependency>
 
       <dependency>
         <groupId>org.graalvm.js</groupId>

--- a/distro/run4/pom.xml
+++ b/distro/run4/pom.xml
@@ -25,22 +25,14 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
-      
-      <!-- Override Tomcat version from Spring Boot BOM -->
+
+      <!-- Override Tomcat versions from Spring Boot BOM for all Tomcat artifacts -->
       <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-core</artifactId>
+        <groupId>org.apache.tomcat</groupId>
+        <artifactId>tomcat-bom</artifactId>
         <version>${version.tomcat.springboot4}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-el</artifactId>
-        <version>${version.tomcat.springboot4}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-websocket</artifactId>
-        <version>${version.tomcat.springboot4}</version>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
 
       <dependency>

--- a/distro/run4/pom.xml
+++ b/distro/run4/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>../../database</relativePath>
   </parent>
 

--- a/distro/run4/pom.xml
+++ b/distro/run4/pom.xml
@@ -26,15 +26,6 @@
         <type>pom</type>
       </dependency>
 
-      <!-- Override Tomcat versions from Spring Boot BOM for all Tomcat artifacts -->
-      <dependency>
-        <groupId>org.apache.tomcat</groupId>
-        <artifactId>tomcat-bom</artifactId>
-        <version>${version.tomcat.springboot4}</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-
       <dependency>
         <groupId>org.graalvm.js</groupId>
         <artifactId>js</artifactId>

--- a/distro/run4/qa/example-plugin/pom.xml
+++ b/distro/run4/qa/example-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.run</groupId>
     <artifactId>cibseven-bpm-run4-qa</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run4/qa/integration-tests/pom.xml
+++ b/distro/run4/qa/integration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.run</groupId>
     <artifactId>cibseven-bpm-run4-qa</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run4/qa/pom.xml
+++ b/distro/run4/qa/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.run</groupId>
     <artifactId>cibseven-bpm-run4-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run4/qa/runtime/pom.xml
+++ b/distro/run4/qa/runtime/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.run</groupId>
     <artifactId>cibseven-bpm-run4-qa</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/sql-script/pom.xml
+++ b/distro/sql-script/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.cibseven.bpm.distro</groupId>

--- a/distro/tomcat/assembly/pom.xml
+++ b/distro/tomcat/assembly/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.cibseven.bpm.tomcat</groupId>
     <artifactId>cibseven-tomcat</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
   
   <properties>

--- a/distro/tomcat/distro/pom.xml
+++ b/distro/tomcat/distro/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.cibseven.bpm.tomcat</groupId>
     <artifactId>cibseven-tomcat</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <name>CIB seven - tomcat Distro</name>

--- a/distro/tomcat/pom.xml
+++ b/distro/tomcat/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-tomcat</artifactId>

--- a/distro/tomcat/webapp-jakarta/pom.xml
+++ b/distro/tomcat/webapp-jakarta/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.cibseven.bpm.tomcat</groupId>
     <artifactId>cibseven-tomcat</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/distro/webjar/pom.xml
+++ b/distro/webjar/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.cibseven.bpm.webapp</groupId>

--- a/distro/wildfly/assembly/pom.xml
+++ b/distro/wildfly/assembly/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.wildfly</groupId>
     <artifactId>cibseven-wildfly</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-wildfly-assembly</artifactId>

--- a/distro/wildfly/distro/pom.xml
+++ b/distro/wildfly/distro/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.wildfly</groupId>
     <artifactId>cibseven-wildfly</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-bpm-wildfly</artifactId>

--- a/distro/wildfly/modules/pom.xml
+++ b/distro/wildfly/modules/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.wildfly</groupId>
     <artifactId>cibseven-wildfly</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-wildfly-modules</artifactId>

--- a/distro/wildfly/pom.xml
+++ b/distro/wildfly/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
   
   <groupId>org.cibseven.bpm.wildfly</groupId>

--- a/distro/wildfly/subsystem/pom.xml
+++ b/distro/wildfly/subsystem/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.wildfly</groupId>
     <artifactId>cibseven-wildfly</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-wildfly-subsystem</artifactId>

--- a/distro/wildfly/webapp/pom.xml
+++ b/distro/wildfly/webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.cibseven.bpm.wildfly</groupId>
     <artifactId>cibseven-wildfly</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/distro/wildfly28/assembly/pom.xml
+++ b/distro/wildfly28/assembly/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.wildfly</groupId>
     <artifactId>cibseven-wildfly28</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-wildfly28-assembly</artifactId>

--- a/distro/wildfly28/distro/pom.xml
+++ b/distro/wildfly28/distro/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.wildfly</groupId>
     <artifactId>cibseven-wildfly28</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-bpm-wildfly28</artifactId>

--- a/distro/wildfly28/modules/pom.xml
+++ b/distro/wildfly28/modules/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.wildfly</groupId>
     <artifactId>cibseven-wildfly28</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-wildfly28-modules</artifactId>

--- a/distro/wildfly28/pom.xml
+++ b/distro/wildfly28/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
   
   <groupId>org.cibseven.bpm.wildfly</groupId>

--- a/distro/wildfly28/subsystem/pom.xml
+++ b/distro/wildfly28/subsystem/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.wildfly</groupId>
     <artifactId>cibseven-wildfly28</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-wildfly28-subsystem</artifactId>

--- a/engine-cdi/core/pom.xml
+++ b/engine-cdi/core/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/engine-cdi/jakarta/pom.xml
+++ b/engine-cdi/jakarta/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/engine-cdi/pom.xml
+++ b/engine-cdi/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-cdi-compatibility-root</artifactId>

--- a/engine-dmn/bom/pom.xml
+++ b/engine-dmn/bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 

--- a/engine-dmn/engine/pom.xml
+++ b/engine-dmn/engine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.dmn</groupId>
     <artifactId>cibseven-engine-dmn-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-engine-dmn</artifactId>

--- a/engine-dmn/feel-api/pom.xml
+++ b/engine-dmn/feel-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.dmn</groupId>
     <artifactId>cibseven-engine-dmn-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-engine-feel-api</artifactId>

--- a/engine-dmn/feel-juel/pom.xml
+++ b/engine-dmn/feel-juel/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.dmn</groupId>
     <artifactId>cibseven-engine-dmn-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-engine-feel-juel</artifactId>

--- a/engine-dmn/feel-scala/pom.xml
+++ b/engine-dmn/feel-scala/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.dmn</groupId>
     <artifactId>cibseven-engine-dmn-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-engine-feel-scala</artifactId>

--- a/engine-dmn/pom.xml
+++ b/engine-dmn/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.cibseven.bpm.dmn</groupId>

--- a/engine-plugins/connect-plugin/pom.xml
+++ b/engine-plugins/connect-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>cibseven-engine-plugins</artifactId>
     <groupId>org.cibseven.bpm</groupId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/engine-plugins/identity-ldap/pom.xml
+++ b/engine-plugins/identity-ldap/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-engine-plugins</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/engine-plugins/pom.xml
+++ b/engine-plugins/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-engine-plugins</artifactId>

--- a/engine-plugins/spin-plugin/pom.xml
+++ b/engine-plugins/spin-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>cibseven-engine-plugins</artifactId>
     <groupId>org.cibseven.bpm</groupId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/engine-rest/assembly-jakarta/pom.xml
+++ b/engine-rest/assembly-jakarta/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-engine-rest-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/engine-rest/assembly/pom.xml
+++ b/engine-rest/assembly/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-engine-rest-root</artifactId>
     <relativePath>../</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
   
   <properties>

--- a/engine-rest/docs/pom.xml
+++ b/engine-rest/docs/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>cibseven-engine-rest-root</artifactId>
     <groupId>org.cibseven.bpm</groupId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/engine-rest/engine-rest-jakarta/pom.xml
+++ b/engine-rest/engine-rest-jakarta/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-engine-rest-root</artifactId>
     <relativePath>../</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/engine-rest/engine-rest-openapi-generator/pom.xml
+++ b/engine-rest/engine-rest-openapi-generator/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-engine-rest-root</artifactId>
     <relativePath>../</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/engine-rest/engine-rest-openapi/pom.xml
+++ b/engine-rest/engine-rest-openapi/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-engine-rest-root</artifactId>
     <relativePath>../</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-engine-rest-root</artifactId>
     <relativePath>../</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/engine-rest/pom.xml
+++ b/engine-rest/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-engine-rest-root</artifactId>

--- a/engine-spring/core-6/pom.xml
+++ b/engine-spring/core-6/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/engine-spring/core-7/pom.xml
+++ b/engine-spring/core-7/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/engine-spring/core/pom.xml
+++ b/engine-spring/core/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/engine-spring/pom.xml
+++ b/engine-spring/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-spring-compatibility-root</artifactId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/examples/invoice-jakarta/pom.xml
+++ b/examples/invoice-jakarta/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.cibseven.bpm.example</groupId>
     <artifactId>cibseven-example-root</artifactId>
     <relativePath>../</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/examples/invoice/pom.xml
+++ b/examples/invoice/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.cibseven.bpm.example</groupId>
     <artifactId>cibseven-example-root</artifactId>
     <relativePath>../</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/freemarker-template-engine/pom.xml
+++ b/freemarker-template-engine/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-parent</artifactId>
     <relativePath>../parent</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.cibseven.template-engines</groupId>

--- a/internal-dependencies/pom.xml
+++ b/internal-dependencies/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-parent</artifactId>
     <relativePath>../parent</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-core-internal-dependencies</artifactId>

--- a/javaee/ejb-client-jakarta/pom.xml
+++ b/javaee/ejb-client-jakarta/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/javaee/ejb-client/pom.xml
+++ b/javaee/ejb-client/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/javaee/ejb-service/pom.xml
+++ b/javaee/ejb-service/pom.xml
@@ -11,7 +11,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/javaee/jobexecutor-ra/pom.xml
+++ b/javaee/jobexecutor-ra/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/javaee/jobexecutor-rar/pom.xml
+++ b/javaee/jobexecutor-rar/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/juel/pom.xml
+++ b/juel/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.cibseven.bpm.juel</groupId>

--- a/model-api/bpmn-model/pom.xml
+++ b/model-api/bpmn-model/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.cibseven.bpm.model</groupId>
     <artifactId>cibseven-model-apis</artifactId>
     <relativePath>../</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-bpmn-model</artifactId>

--- a/model-api/cmmn-model/pom.xml
+++ b/model-api/cmmn-model/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.cibseven.bpm.model</groupId>
     <artifactId>cibseven-model-apis</artifactId>
     <relativePath>../</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-cmmn-model</artifactId>

--- a/model-api/dmn-model/pom.xml
+++ b/model-api/dmn-model/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.cibseven.bpm.model</groupId>
     <artifactId>cibseven-model-apis</artifactId>
     <relativePath>../</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-dmn-model</artifactId>

--- a/model-api/pom.xml
+++ b/model-api/pom.xml
@@ -12,7 +12,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/model-api/xml-model/pom.xml
+++ b/model-api/xml-model/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.cibseven.bpm.model</groupId>
     <artifactId>cibseven-model-apis</artifactId>
     <relativePath>../</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-xml-model</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -22,8 +22,8 @@
     <version.spring.framework>5.3.39</version.spring.framework>
     <version.spring.framework6>6.2.11</version.spring.framework6>
     <version.spring.framework7>7.0.6</version.spring.framework7>
-    <version.spring-boot>3.5.12</version.spring-boot>
-    <version.spring-boot4>4.0.4</version.spring-boot4>
+    <version.spring-boot>3.5.13</version.spring-boot>
+    <version.spring-boot4>4.0.5</version.spring-boot4>
     <version.resteasy>3.15.6.Final</version.resteasy>
     <version.jersey2>2.34</version.jersey2>
     <!-- use minimum version of resteasy and jersey -->
@@ -70,9 +70,8 @@
     <version.wildfly28>28.0.1.Final</version.wildfly28>
     <version.wildfly28.core>20.0.2.Final</version.wildfly28.core>
 
-    <version.tomcat9>9.0.110</version.tomcat9>
+    <version.tomcat9>9.0.117</version.tomcat9>
     <version.tomcat>10.1.54</version.tomcat>
-    <version.tomcat.springboot4>11.0.21</version.tomcat.springboot4>
 
     <version.arquillian>1.1.10.Final</version.arquillian>
     <version.shrinkwrap.resolvers>2.2.2</version.shrinkwrap.resolvers>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -71,7 +71,7 @@
     <version.wildfly28.core>20.0.2.Final</version.wildfly28.core>
 
     <version.tomcat9>9.0.110</version.tomcat9>
-    <version.tomcat>10.1.52</version.tomcat>
+    <version.tomcat>10.1.54</version.tomcat>
 
     <version.arquillian>1.1.10.Final</version.arquillian>
     <version.shrinkwrap.resolvers>2.2.2</version.shrinkwrap.resolvers>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -72,6 +72,7 @@
 
     <version.tomcat9>9.0.110</version.tomcat9>
     <version.tomcat>10.1.54</version.tomcat>
+    <version.tomcat.springboot4>11.0.21</version.tomcat.springboot4>
 
     <version.arquillian>1.1.10.Final</version.arquillian>
     <version.shrinkwrap.resolvers>2.2.2</version.shrinkwrap.resolvers>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.cibseven.bpm</groupId>
   <artifactId>cibseven-root</artifactId>
-  <version>2.2.0-SNAPSHOT</version>
+  <version>2.2.0-alpha1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>CIB seven - Root Pom</name>
   <inceptionYear>2024</inceptionYear>

--- a/qa/ensure-clean-db-plugin/pom.xml
+++ b/qa/ensure-clean-db-plugin/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>cibseven-qa</artifactId>
     <groupId>org.cibseven.bpm.qa</groupId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/qa/integration-tests-engine-jakarta/pom.xml
+++ b/qa/integration-tests-engine-jakarta/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.cibseven.bpm.qa</groupId>
     <artifactId>cibseven-qa</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/qa/integration-tests-engine/pom.xml
+++ b/qa/integration-tests-engine/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.cibseven.bpm.qa</groupId>
     <artifactId>cibseven-qa</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/qa/integration-tests-webapps/integration-tests/pom.xml
+++ b/qa/integration-tests-webapps/integration-tests/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.cibseven.bpm.qa</groupId>
     <artifactId>cibseven-qa-integration-tests-webapps-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
   

--- a/qa/integration-tests-webapps/pom.xml
+++ b/qa/integration-tests-webapps/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.cibseven.bpm.qa</groupId>
     <artifactId>cibseven-qa</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/qa/integration-tests-webapps/shared-engine/pom.xml
+++ b/qa/integration-tests-webapps/shared-engine/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.cibseven.bpm.qa</groupId>
     <artifactId>cibseven-qa-integration-tests-webapps-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/qa/large-data-tests/pom.xml
+++ b/qa/large-data-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.cibseven.bpm.qa</groupId>
     <artifactId>cibseven-qa</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/qa/performance-tests-engine/pom.xml
+++ b/qa/performance-tests-engine/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.cibseven.bpm.qa</groupId>
     <artifactId>cibseven-qa</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -11,7 +11,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/qa/test-db-indexes-in-scripts/pom.xml
+++ b/qa/test-db-indexes-in-scripts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.qa</groupId>
     <artifactId>cibseven-qa</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.cibseven.bpm.qa</groupId>

--- a/qa/test-db-instance-migration/pom.xml
+++ b/qa/test-db-instance-migration/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.cibseven.bpm.qa</groupId>
     <artifactId>cibseven-qa</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/qa/test-db-instance-migration/test-fixture-11/pom.xml
+++ b/qa/test-db-instance-migration/test-fixture-11/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.qa.upgrade</groupId>
     <artifactId>cibseven-qa-db-instance-migration</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-qa-upgrade-test-fixture-11</artifactId>

--- a/qa/test-db-instance-migration/test-fixture-20/pom.xml
+++ b/qa/test-db-instance-migration/test-fixture-20/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.qa.upgrade</groupId>
     <artifactId>cibseven-qa-db-instance-migration</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-qa-upgrade-test-fixture-20</artifactId>

--- a/qa/test-db-instance-migration/test-fixture-21/pom.xml
+++ b/qa/test-db-instance-migration/test-fixture-21/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.qa.upgrade</groupId>
     <artifactId>cibseven-qa-db-instance-migration</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-qa-upgrade-test-fixture-21</artifactId>

--- a/qa/test-db-instance-migration/test-migration/pom.xml
+++ b/qa/test-db-instance-migration/test-migration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.qa.upgrade</groupId>
     <artifactId>cibseven-qa-db-instance-migration</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-qa-upgrade-test-migration</artifactId>

--- a/qa/test-db-rolling-update/create-new-engine/pom.xml
+++ b/qa/test-db-rolling-update/create-new-engine/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.qa.upgrade</groupId>
     <artifactId>cibseven-qa-db-rolling-update</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-qa-db-create-new-engine</artifactId>

--- a/qa/test-db-rolling-update/create-old-engine/pom.xml
+++ b/qa/test-db-rolling-update/create-old-engine/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.qa.upgrade</groupId>
     <artifactId>cibseven-qa-db-rolling-update</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-qa-db-create-old-engine</artifactId>

--- a/qa/test-db-rolling-update/pom.xml
+++ b/qa/test-db-rolling-update/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.cibseven.bpm.qa</groupId>
     <artifactId>cibseven-qa</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <modules>

--- a/qa/test-db-rolling-update/rolling-update-util/pom.xml
+++ b/qa/test-db-rolling-update/rolling-update-util/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.qa.upgrade</groupId>
     <artifactId>cibseven-qa-db-rolling-update</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-qa-db-rolling-update-util</artifactId>

--- a/qa/test-db-rolling-update/test-old-engine/pom.xml
+++ b/qa/test-db-rolling-update/test-old-engine/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.qa.upgrade</groupId>
     <artifactId>cibseven-qa-db-rolling-update</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
 

--- a/qa/test-db-util/pom.xml
+++ b/qa/test-db-util/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.qa</groupId>
     <artifactId>cibseven-qa</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.cibseven.bpm.qa.upgrade</groupId>

--- a/qa/test-old-engine/pom.xml
+++ b/qa/test-old-engine/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.qa</groupId>
     <artifactId>cibseven-qa</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-qa-old-engine</artifactId>

--- a/qa/tomcat-runtime/pom.xml
+++ b/qa/tomcat-runtime/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.cibseven.bpm.qa</groupId>
     <artifactId>cibseven-qa</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/qa/tomcat9-runtime/pom.xml
+++ b/qa/tomcat9-runtime/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.cibseven.bpm.qa</groupId>
     <artifactId>cibseven-qa</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/qa/wildfly-runtime/pom.xml
+++ b/qa/wildfly-runtime/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.cibseven.bpm.qa</groupId>
     <artifactId>cibseven-qa</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
 

--- a/quarkus-extension/engine/deployment/pom.xml
+++ b/quarkus-extension/engine/deployment/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.cibseven.bpm.quarkus</groupId>
     <artifactId>cibseven-bpm-quarkus-engine-parent</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-bpm-quarkus-engine-deployment</artifactId>

--- a/quarkus-extension/engine/pom.xml
+++ b/quarkus-extension/engine/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>cibseven-bpm-quarkus-parent</artifactId>
     <groupId>org.cibseven.bpm.quarkus</groupId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-bpm-quarkus-engine-parent</artifactId>

--- a/quarkus-extension/engine/qa/pom.xml
+++ b/quarkus-extension/engine/qa/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.cibseven.bpm.quarkus</groupId>
     <artifactId>cibseven-bpm-quarkus-engine-parent</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/quarkus-extension/engine/runtime/pom.xml
+++ b/quarkus-extension/engine/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.cibseven.bpm.quarkus</groupId>
     <artifactId>cibseven-bpm-quarkus-engine-parent</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-bpm-quarkus-engine</artifactId>

--- a/quarkus-extension/pom.xml
+++ b/quarkus-extension/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-bpm-quarkus-parent</artifactId>

--- a/spin/bom/pom.xml
+++ b/spin/bom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/spin/core/pom.xml
+++ b/spin/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.spin</groupId>
     <artifactId>cibseven-spin-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-spin-core</artifactId>

--- a/spin/dataformat-all/pom.xml
+++ b/spin/dataformat-all/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.spin</groupId>
     <artifactId>cibseven-spin-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-spin-dataformat-all</artifactId>

--- a/spin/dataformat-json-jackson/pom.xml
+++ b/spin/dataformat-json-jackson/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.spin</groupId>
     <artifactId>cibseven-spin-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-spin-dataformat-json-jackson</artifactId>

--- a/spin/dataformat-xml-dom-jakarta/pom.xml
+++ b/spin/dataformat-xml-dom-jakarta/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.spin</groupId>
     <artifactId>cibseven-spin-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-spin-dataformat-xml-dom-jakarta</artifactId>

--- a/spin/dataformat-xml-dom/pom.xml
+++ b/spin/dataformat-xml-dom/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.spin</groupId>
     <artifactId>cibseven-spin-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-spin-dataformat-xml-dom</artifactId>

--- a/spin/pom.xml
+++ b/spin/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-parent</artifactId>
     <relativePath>../parent</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.cibseven.spin</groupId>

--- a/spring-boot-4-starter/pom.xml
+++ b/spring-boot-4-starter/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.cibseven.bpm.springboot.project</groupId>

--- a/spring-boot-4-starter/starter-client/spring-boot/pom.xml
+++ b/spring-boot-4-starter/starter-client/spring-boot/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.springboot.project</groupId>
     <artifactId>cibseven-bpm-spring-boot-4-starter-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/spring-boot-4-starter/starter-rest/pom.xml
+++ b/spring-boot-4-starter/starter-rest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.springboot.project</groupId>
     <artifactId>cibseven-bpm-spring-boot-4-starter-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.cibseven.bpm.springboot</groupId>

--- a/spring-boot-4-starter/starter-security/pom.xml
+++ b/spring-boot-4-starter/starter-security/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.springboot.project</groupId>
     <artifactId>cibseven-bpm-spring-boot-4-starter-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.cibseven.bpm.springboot</groupId>

--- a/spring-boot-4-starter/starter-test/pom.xml
+++ b/spring-boot-4-starter/starter-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.springboot.project</groupId>
     <artifactId>cibseven-bpm-spring-boot-4-starter-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.cibseven.bpm.springboot</groupId>

--- a/spring-boot-4-starter/starter-webapp-core/pom.xml
+++ b/spring-boot-4-starter/starter-webapp-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.springboot.project</groupId>
     <artifactId>cibseven-bpm-spring-boot-4-starter-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.cibseven.bpm.springboot</groupId>

--- a/spring-boot-4-starter/starter-webapp/pom.xml
+++ b/spring-boot-4-starter/starter-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.springboot.project</groupId>
     <artifactId>cibseven-bpm-spring-boot-4-starter-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.cibseven.bpm.springboot</groupId>

--- a/spring-boot-4-starter/starter/pom.xml
+++ b/spring-boot-4-starter/starter/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.cibseven.bpm.springboot.project</groupId>
     <artifactId>cibseven-bpm-spring-boot-4-starter-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.cibseven.bpm.springboot</groupId>

--- a/spring-boot-starter/pom.xml
+++ b/spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.cibseven.bpm.springboot.project</groupId>

--- a/spring-boot-starter/pom.xml
+++ b/spring-boot-starter/pom.xml
@@ -18,8 +18,6 @@
   <properties>
     <!-- disable parallel unit tests run -->
     <surefire.forkCount>1</surefire.forkCount>
-    <!-- Spring Boot will automatically apply tomcat.version to all Tomcat modules -->
-    <tomcat.version>${version.tomcat}</tomcat.version>
   </properties>
 
   <dependencyManagement>

--- a/spring-boot-starter/pom.xml
+++ b/spring-boot-starter/pom.xml
@@ -18,6 +18,8 @@
   <properties>
     <!-- disable parallel unit tests run -->
     <surefire.forkCount>1</surefire.forkCount>
+    <!-- Spring Boot will automatically apply tomcat.version to all Tomcat modules -->
+    <tomcat.version>${version.tomcat}</tomcat.version>
   </properties>
 
   <dependencyManagement>

--- a/spring-boot-starter/starter-client/spring-boot/pom.xml
+++ b/spring-boot-starter/starter-client/spring-boot/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.springboot.project</groupId>
     <artifactId>cibseven-bpm-spring-boot-starter-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/spring-boot-starter/starter-client/spring/pom.xml
+++ b/spring-boot-starter/starter-client/spring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.springboot.project</groupId>
     <artifactId>cibseven-bpm-spring-boot-starter-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/spring-boot-starter/starter-qa/integration-test-liquibase/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-liquibase/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.cibseven.bpm.springboot.project</groupId>
     <artifactId>cibseven-bpm-spring-boot-starter-qa</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>qa-liquibase</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-plugins/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-plugins/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.cibseven.bpm.springboot.project</groupId>
     <artifactId>cibseven-bpm-spring-boot-starter-qa</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/spring-boot-starter/starter-qa/integration-test-plugins/spin/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-plugins/spin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.cibseven.bpm.springboot.project</groupId>
     <artifactId>qa-plugins</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-all/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-all/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.cibseven.bpm.springboot.project</groupId>
     <artifactId>qa-plugins-spin</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>qa-plugins-spin-dataformat-all</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-json-jackson/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-json-jackson/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.cibseven.bpm.springboot.project</groupId>
     <artifactId>qa-plugins-spin</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>qa-plugins-spin-dataformat-json-jackson</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-request-scope/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-request-scope/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.cibseven.bpm.springboot.project</groupId>
     <artifactId>cibseven-bpm-spring-boot-starter-qa</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>qa-request-scope</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-simple/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-simple/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.cibseven.bpm.springboot.project</groupId>
     <artifactId>cibseven-bpm-spring-boot-starter-qa</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>qa-simple</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-webapp/invoice-example/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-webapp/invoice-example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.cibseven.bpm.springboot.project</groupId>
     <artifactId>qa-webapp</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>qa-webapp-invoice-example</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-webapp/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-webapp/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.cibseven.bpm.springboot.project</groupId>
     <artifactId>cibseven-bpm-spring-boot-starter-qa</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/spring-boot-starter/starter-qa/integration-test-webapp/runtime/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-webapp/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.cibseven.bpm.springboot.project</groupId>
     <artifactId>qa-webapp</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>qa-webapp-ce-runtime</artifactId>

--- a/spring-boot-starter/starter-qa/pom.xml
+++ b/spring-boot-starter/starter-qa/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.cibseven.bpm.springboot.project</groupId>
     <artifactId>cibseven-bpm-spring-boot-starter-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/spring-boot-starter/starter-rest/pom.xml
+++ b/spring-boot-starter/starter-rest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.springboot.project</groupId>
     <artifactId>cibseven-bpm-spring-boot-starter-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.cibseven.bpm.springboot</groupId>

--- a/spring-boot-starter/starter-security/pom.xml
+++ b/spring-boot-starter/starter-security/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.springboot.project</groupId>
     <artifactId>cibseven-bpm-spring-boot-starter-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.cibseven.bpm.springboot</groupId>

--- a/spring-boot-starter/starter-test/pom.xml
+++ b/spring-boot-starter/starter-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.cibseven.bpm.springboot.project</groupId>
     <artifactId>cibseven-bpm-spring-boot-starter-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.cibseven.bpm.springboot</groupId>

--- a/spring-boot-starter/starter-webapp-core/pom.xml
+++ b/spring-boot-starter/starter-webapp-core/pom.xml
@@ -10,6 +10,12 @@
   <groupId>org.cibseven.bpm.springboot</groupId>
   <artifactId>cibseven-bpm-spring-boot-starter-webapp-core</artifactId>
   <name>CIB seven - Spring Boot Starter - Webapps Core</name>
+  
+  <!--Spring Boot will automatically apply tomcat.version to all Tomcat modules-->
+  <properties>
+    <tomcat.version>${version.tomcat}</tomcat.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/spring-boot-starter/starter-webapp-core/pom.xml
+++ b/spring-boot-starter/starter-webapp-core/pom.xml
@@ -11,11 +11,6 @@
   <artifactId>cibseven-bpm-spring-boot-starter-webapp-core</artifactId>
   <name>CIB seven - Spring Boot Starter - Webapps Core</name>
   
-  <!--Spring Boot will automatically apply tomcat.version to all Tomcat modules-->
-  <properties>
-    <tomcat.version>${version.tomcat}</tomcat.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/spring-boot-starter/starter-webapp-core/pom.xml
+++ b/spring-boot-starter/starter-webapp-core/pom.xml
@@ -10,7 +10,6 @@
   <groupId>org.cibseven.bpm.springboot</groupId>
   <artifactId>cibseven-bpm-spring-boot-starter-webapp-core</artifactId>
   <name>CIB seven - Spring Boot Starter - Webapps Core</name>
-  
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/spring-boot-starter/starter-webapp-core/pom.xml
+++ b/spring-boot-starter/starter-webapp-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.springboot.project</groupId>
     <artifactId>cibseven-bpm-spring-boot-starter-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.cibseven.bpm.springboot</groupId>

--- a/spring-boot-starter/starter-webapp/pom.xml
+++ b/spring-boot-starter/starter-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven.bpm.springboot.project</groupId>
     <artifactId>cibseven-bpm-spring-boot-starter-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.cibseven.bpm.springboot</groupId>

--- a/spring-boot-starter/starter/pom.xml
+++ b/spring-boot-starter/starter/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.cibseven.bpm.springboot.project</groupId>
     <artifactId>cibseven-bpm-spring-boot-starter-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.cibseven.bpm.springboot</groupId>

--- a/test-utils/archunit/pom.xml
+++ b/test-utils/archunit/pom.xml
@@ -9,7 +9,7 @@
         <groupId>org.cibseven.bpm</groupId>
         <artifactId>cibseven-database-settings</artifactId>
         <relativePath>../../database</relativePath>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>2.2.0-alpha1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/test-utils/assert/core/pom.xml
+++ b/test-utils/assert/core/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-bpm-assert-root</artifactId>
     <relativePath>../</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
   
   <dependencies>

--- a/test-utils/assert/pom.xml
+++ b/test-utils/assert/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/test-utils/assert/qa/pom.xml
+++ b/test-utils/assert/qa/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-bpm-assert-root</artifactId>
     <relativePath>../</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/test-utils/junit5-extension-dmn/pom.xml
+++ b/test-utils/junit5-extension-dmn/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>../../database</relativePath>
   </parent>
 

--- a/test-utils/junit5-extension/pom.xml
+++ b/test-utils/junit5-extension/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/test-utils/testcontainers/pom.xml
+++ b/test-utils/testcontainers/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cibseven-test-utils-testcontainers</artifactId>

--- a/webapps/assembly-jakarta/pom.xml
+++ b/webapps/assembly-jakarta/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.cibseven.bpm.webapp</groupId>
     <artifactId>cibseven-webapp-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/webapps/assembly/pom.xml
+++ b/webapps/assembly/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.cibseven.bpm.webapp</groupId>
     <artifactId>cibseven-webapp-root</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/webapps/pom.xml
+++ b/webapps/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.cibseven.bpm</groupId>
     <artifactId>cibseven-database-settings</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-alpha1-SNAPSHOT</version>
     <relativePath>../database</relativePath>
   </parent>
 


### PR DESCRIPTION
forked from release alpha branch.
Run distro (Spring Boot 3.5.12): upgrade tomcat from 10.1.52 to 10.1.54.
Run4 distro (Sprig Boot 4.0.4): upgrade tomcat from 11.0.18 to 11.0.21