### PR TITLE
fix(engine): Distinguish new process instance from executions going from other executions from start node

### DIFF
--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/persistence/entity/ExecutionEntity.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/persistence/entity/ExecutionEntity.java
@@ -102,6 +102,14 @@ public class ExecutionEntity extends PvmExecutionImpl implements Execution, Proc
 
   protected static final EnginePersistenceLogger LOG = ProcessEngineLogger.PERSISTENCE_LOGGER;
 
+  /**
+   * Process instance ID that can be used in 
+   * DefaultAuthorizationProvider.newProcessInstance() to distinguish the
+   * process instance from executions going from the start event element in
+   * the process definition.
+   */
+  protected static final String NEW_PROCESS_INSTANCE_TEMP_ID = "NEW";
+
   // Persistent refrenced entities state //////////////////////////////////////
   public static final int EVENT_SUBSCRIPTIONS_STATE_BIT = 1;
   public static final int TASKS_STATE_BIT = 2;
@@ -323,6 +331,18 @@ public class ExecutionEntity extends PvmExecutionImpl implements Execution, Proc
 
   protected static ExecutionEntity createNewExecution() {
     ExecutionEntity newExecution = new ExecutionEntity();
+    initializeAssociations(newExecution);
+    newExecution.insert();
+
+    return newExecution;
+  }
+
+  // necessary to be able to distinguish process instance from paths going from the start of the process
+  protected static ExecutionEntity createNewProcessInstanceExecution() {
+    ExecutionEntity newExecution = new ExecutionEntity();
+    // assign some temporary process instance ID as it will be relaced later with actual ID that will be generated
+    // it has to be assigned directly, as using setProcessInstance() is comparing it with this execution ID which is not yet assigned
+    newExecution.processInstanceId = NEW_PROCESS_INSTANCE_TEMP_ID;
     initializeAssociations(newExecution);
     newExecution.insert();
 

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/persistence/entity/ProcessDefinitionEntity.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/persistence/entity/ProcessDefinitionEntity.java
@@ -113,7 +113,7 @@ public class ProcessDefinitionEntity extends ProcessDefinitionImpl implements Pr
 
   @Override
   protected PvmExecutionImpl newProcessInstance() {
-    ExecutionEntity newExecution = ExecutionEntity.createNewExecution();
+    ExecutionEntity newExecution = ExecutionEntity.createNewProcessInstanceExecution();
 
     if(tenantId != null) {
       newExecution.setTenantId(tenantId);


### PR DESCRIPTION
When someone wants to implement it's own `ResourceAuthorizationProvider.newProcessInstance()` when new process instance is created, this method is called multiple times. Once for the process instance itself, but also for all executions (links) from the start event element defined in the process definition.

Reason is that when execution is being created (process instance is also an execution) it is first sent to be stored into the storage and only later process instance specific fields are being assigned to the java object. One of the reason is that ID of the execution is generating during the storing of the execution.

So to be able to distinguish the process instance itself from other executions while creating the process instance following steps has been performed:
1. Defined the placeholder to be used as a temporary process instance ID until actual identifier will be generated
1. Create new method that sets this placeholder to the Java object
1. Call the new method when creating new process instance instead of creating generic execution
This way it is at least distinguis the process instance from other executions.

Potentionally it is a question whether this new placeholder should be used also in `ExecutionManager.createDefaultAuthorizations()` to filter out other executions so that `ResourceAuthorizationProvider.newProcessInstance()` will be called really only for the process instance itself and not other executions...

Here is attached minimal reproducible example: [cibseven-new-process-instance-poc.zip](https://github.com/user-attachments/files/27242139/cibseven-new-process-instance-poc.zip), steps to reproduce are:
1. download Tomcat distribution
1. copy plugin `cibseven-new-process-instance-poc-1.0.0.jar` to `server\apache-tomcat-10.1.47\lib\`
1. add  server\apache-tomcat-10.1.47\conf\bpm-platform.xml
```
      <plugin>
        <class>org.example.cibseven.plugin.CustomAuthorizationPlugin</class>
      </plugin>
```
4. start CIB seven
1. deploy process definition `cibseven-new-process-instance-poc.bpmn`
1. start new process instance of that definition
1. `newProcessInstance has been called for command ...` is logged 4 times, which is the number of links from the start node of the process definition
which results to create new authorizations in the database for all 4 object. Which is not correct as only one of that is process instance, but can't be distinguished anyhow.

Expected behavior: `ResourceAuthorizationProvider.newProcessInstance()` method to be called just once for each new process instance no matter how many links are there from the start node of the process definition. Or at least be able to distinguish actual process instance within that method from other executions.

Our use case is that we don't want everyone (or specified groups) have access to all process instances (or instances from some process definition). So we need to grant authorization during creation of the process instance.

Originaly the same PR was opened for Camunda as https://github.com/camunda/camunda-bpm-platform/pull/4881. Additional discussion about it happened in https://github.com/camunda/camunda-bpm-platform/issues/4890 (which should now be https://github.com/camunda/camunda-bpm-platform-maintenance/issues/1667 that is not publically accassible, not even for me). Comment the last message in the PR is referring to was:
> I agree that the reported behavior is a bug. I've updated the issue to include my findings.
>
> Unfortunately, any change to Camunda's Process Virtual Machine requires a considerable amount of engineering effort to test and prevent unwanted side effects. Given that 7.24 will be the final minor release for Camunda 7 Community Edition, we won't be able to include a fix for this in the CE distribution. I'm going to close this PR.
>
> I investigated whether we could offer a workaround to differentiate process instances from other executions in a CustomDefaultAuthorizationProvider. From what I could determine, during the initialization phase, all ExecutionEntity objects (both actual ProcessInstances and child executions) appear to have identical structural properties, making reliable differentiation challenging through the standard API methods I explored.
>
> Thank you for your contribution in identifying this edge case.