### PR TITLE
new(engine): check for task Id before assigning a variable

### DIFF
--- a/Jenkinsfile.cib
+++ b/Jenkinsfile.cib
@@ -4,7 +4,6 @@
 
 import de.cib.pipeline.library.Constants
 import de.cib.pipeline.library.kubernetes.BuildPodCreator
-import de.cib.pipeline.library.logging.Logger
 import de.cib.pipeline.library.ConstantsInternal
 import de.cib.pipeline.library.MavenProjectInformation
 import groovy.transform.Field
@@ -131,12 +130,12 @@ pipeline {
                     def groupId = pom.groupId
                     if (groupId == null) {
                         groupId = pom.parent.groupId
-                        log.info "parent groupId is used"
+                        echo "parent groupId is used"
                     }
 
                     mavenProjectInformation = new MavenProjectInformation(groupId, pom.artifactId, pom.version, pom.name, pom.description)
 
-                    log.info "Build Project: ${mavenProjectInformation.groupId}:${mavenProjectInformation.artifactId}, ${mavenProjectInformation.name} with version ${mavenProjectInformation.version}"
+                    echo "Build Project: ${mavenProjectInformation.groupId}:${mavenProjectInformation.artifactId}, ${mavenProjectInformation.name} with version ${mavenProjectInformation.version}"
                     // Avoid Git "dubious ownership" error in checked out repository. Needed in
                     // build containers with newer Git versions. Originates from Jenkins running
                     // pipeline as root but repository being owned by user 1000. For more, see
@@ -592,7 +591,7 @@ pipeline {
     post {
         always {
             script {
-                log.info 'End of the build'
+                echo 'End of the build'
 
                 // move back to the repo pool to reuse
                 if (params.USE_PRIVATE_REPO) {
@@ -603,19 +602,19 @@ pipeline {
 
         success {
             script {
-                log.info '✅ Build successful'
+                echo '✅ Build successful'
             }
         }
 
         unstable {
             script {
-                log.warning '⚠️ Build unstable'
+                echo '⚠️ Build unstable'
             }
         }
 
         failure {
             script {
-                log.warning '❌ Build failed'
+                echo '❌ Build failed'
                 if (env.BRANCH_NAME == 'main') {
                     notifyResult(
                         office365WebhookId: pipelineParams.office365WebhookId,
@@ -627,7 +626,7 @@ pipeline {
 
         fixed {
             script {
-                log.info '✅ Previous issues fixed'
+                echo '✅ Previous issues fixed'
                 if (env.BRANCH_NAME == 'main') {
                     notifyResult(
                         office365WebhookId: pipelineParams.office365WebhookId,

--- a/Jenkinsfile.cib
+++ b/Jenkinsfile.cib
@@ -8,7 +8,6 @@ import de.cib.pipeline.library.ConstantsInternal
 import de.cib.pipeline.library.MavenProjectInformation
 import groovy.transform.Field
 
-@Field Logger log = new Logger(this)
 @Field MavenProjectInformation mavenProjectInformation = null
 @Field String mavenLocalRepoRedirected = null
 @Field Map pipelineParams = [

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -639,6 +639,13 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
    */
   protected boolean standaloneTasksEnabled = true;
 
+  /**
+   * When set to false, the engine will validate that the TASK_ID_ referenced
+   * by a variable exists in ACT_RU_TASK before inserting the variable into ACT_RU_VARIABLE.
+   * This prevents orphaned task variable references.
+   */
+  protected boolean checkVariableTaskId = false;
+
   protected boolean enableGracefulDegradationOnContextSwitchFailure = true;
 
   protected BusinessCalendarManager businessCalendarManager;
@@ -4313,6 +4320,15 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   public ProcessEngineConfigurationImpl setStandaloneTasksEnabled(boolean standaloneTasksEnabled) {
     this.standaloneTasksEnabled = standaloneTasksEnabled;
+    return this;
+  }
+
+  public boolean isCheckVariableTaskId() {
+    return checkVariableTaskId;
+  }
+
+  public ProcessEngineConfigurationImpl setCheckVariableTaskId(boolean checkVariableTaskId) {
+    this.checkVariableTaskId = checkVariableTaskId;
     return this;
   }
 

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -640,7 +640,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   protected boolean standaloneTasksEnabled = true;
 
   /**
-   * When set to false, the engine will validate that the TASK_ID_ referenced
+   * When set to true, the engine will validate that the TASK_ID_ referenced
    * by a variable exists in ACT_RU_TASK before inserting the variable into ACT_RU_VARIABLE.
    * This prevents orphaned task variable references.
    */

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/persistence/entity/VariableInstanceEntity.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/persistence/entity/VariableInstanceEntity.java
@@ -26,7 +26,9 @@ import java.util.concurrent.Callable;
 import org.cibseven.bpm.application.InvocationContext;
 import org.cibseven.bpm.application.ProcessApplicationReference;
 import org.cibseven.bpm.engine.delegate.VariableScope;
+import org.cibseven.bpm.engine.ProcessEngineException;
 import org.cibseven.bpm.engine.impl.ProcessEngineLogger;
+import org.cibseven.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.cibseven.bpm.engine.impl.cmmn.entity.runtime.CaseExecutionEntity;
 import org.cibseven.bpm.engine.impl.context.Context;
 import org.cibseven.bpm.engine.impl.context.ProcessApplicationContextUtil;
@@ -144,10 +146,29 @@ public class VariableInstanceEntity implements VariableInstance, CoreVariableIns
 
   public static void insert(VariableInstanceEntity variableInstance) {
     if (!variableInstance.isTransient()) {
+      validateTaskIdIfEnabled(variableInstance);
       Context
       .getCommandContext()
       .getDbEntityManager()
       .insert(variableInstance);
+    }
+  }
+
+  protected static void validateTaskIdIfEnabled(VariableInstanceEntity variableInstance) {
+    String taskId = variableInstance.getTaskId();
+    if (taskId != null) {
+      ProcessEngineConfigurationImpl config = Context.getProcessEngineConfiguration();
+      if (config != null && config.isCheckVariableTaskId()) {
+        TaskEntity task = Context.getCommandContext()
+            .getTaskManager()
+            .findTaskById(taskId);
+        if (task == null) {
+          throw new ProcessEngineException(
+              "Task with id '" + taskId + "' does not exist. "
+              + "Cannot create variable '" + variableInstance.getName()
+              + "' with a reference to a non-existing task.");
+        }
+      }
     }
   }
 

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/persistence/entity/VariableInstanceEntity.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/persistence/entity/VariableInstanceEntity.java
@@ -162,9 +162,9 @@ public class VariableInstanceEntity implements VariableInstance, CoreVariableIns
         TaskEntity task = variableInstance.getTask();
         if (task == null || task.isDeleted()) {
           throw new ProcessEngineException(
-              "Task with id '" + taskId + "' is already deleted. "
+              "Task with id '" + taskId + "' doesn't exist or it is already completed. "
               + "Cannot create variable '" + variableInstance.getName()
-              + "' with a reference to a deleted task.");
+              + "' with a reference to a not existing task.");
         }
       }
     }

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/persistence/entity/VariableInstanceEntity.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/persistence/entity/VariableInstanceEntity.java
@@ -159,14 +159,12 @@ public class VariableInstanceEntity implements VariableInstance, CoreVariableIns
     if (taskId != null) {
       ProcessEngineConfigurationImpl config = Context.getProcessEngineConfiguration();
       if (config != null && config.isCheckVariableTaskId()) {
-        TaskEntity task = Context.getCommandContext()
-            .getTaskManager()
-            .findTaskById(taskId);
-        if (task == null) {
+        TaskEntity task = variableInstance.getTask();
+        if (task == null || task.isDeleted()) {
           throw new ProcessEngineException(
-              "Task with id '" + taskId + "' does not exist. "
+              "Task with id '" + taskId + "' is already deleted. "
               + "Cannot create variable '" + variableInstance.getName()
-              + "' with a reference to a non-existing task.");
+              + "' with a reference to a deleted task.");
         }
       }
     }

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/persistence/entity/VariableInstanceEntityPersistenceListener.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/persistence/entity/VariableInstanceEntityPersistenceListener.java
@@ -39,6 +39,7 @@ public class VariableInstanceEntityPersistenceListener implements VariableInstan
 
   @Override
   public void onUpdate(VariableInstanceEntity variable, AbstractVariableScope sourceScope) {
+    VariableInstanceEntity.validateTaskIdIfEnabled(variable);
   }
 
 }

--- a/engine/src/test/java/org/cibseven/bpm/engine/impl/cfg/ProcessEngineConfigurationTest.java
+++ b/engine/src/test/java/org/cibseven/bpm/engine/impl/cfg/ProcessEngineConfigurationTest.java
@@ -71,6 +71,15 @@ public class ProcessEngineConfigurationTest {
   }
 
   @Test
+  public void shouldDisableCheckVariableTaskIdByDefault() {
+    // when
+    ProcessEngineConfigurationImpl engineConfiguration = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.createStandaloneProcessEngineConfiguration();
+
+    // then
+    assertThat(engineConfiguration.isCheckVariableTaskId()).isFalse();
+  }
+
+  @Test
   public void shouldUseQuartzCronTypeByDefault() {
     // when
     ProcessEngineConfigurationImpl engineConfiguration = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.createStandaloneProcessEngineConfiguration();

--- a/engine/src/test/java/org/cibseven/bpm/engine/test/api/runtime/VariableInTransactionTest.java
+++ b/engine/src/test/java/org/cibseven/bpm/engine/test/api/runtime/VariableInTransactionTest.java
@@ -16,8 +16,10 @@
  */
 package org.cibseven.bpm.engine.test.api.runtime;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 
+import org.cibseven.bpm.engine.ProcessEngineException;
 import org.cibseven.bpm.engine.impl.db.entitymanager.DbEntityManager;
 import org.cibseven.bpm.engine.impl.db.entitymanager.cache.CachedDbEntity;
 import org.cibseven.bpm.engine.impl.db.entitymanager.cache.DbEntityState;
@@ -60,5 +62,55 @@ public class VariableInTransactionTest extends PluggableProcessEngineTest {
       }
     });
 
+  }
+
+  @Test
+  public void testCreateVariableWithNonExistingTaskIdByDefault() {
+    // given - default config has checkVariableTaskId disabled
+    String nonExistingTaskId = "non-existing-task-id";
+
+    // when - inserting a variable with a non-existing taskId
+    processEngineConfiguration.getCommandExecutorTxRequired().execute(new Command<Void>() {
+      @Override
+      public Void execute(CommandContext commandContext) {
+        VariableInstanceEntity variable = VariableInstanceEntity.create("myVar",
+            Variables.stringValue("myValue"), false);
+        variable.setTaskId(nonExistingTaskId);
+        VariableInstanceEntity.insert(variable);
+
+        // clean up
+        variable.delete();
+        return null;
+      }
+    });
+
+    // then - no exception is thrown
+  }
+
+  @Test
+  public void testCreateVariableWithNonExistingTaskIdWhenCheckEnabled() {
+    // given - enable checkVariableTaskId
+    String nonExistingTaskId = "non-existing-task-id";
+    processEngineConfiguration.setCheckVariableTaskId(true);
+
+    try {
+      // when/then - inserting a variable with a non-existing taskId should fail
+      assertThatThrownBy(() ->
+          processEngineConfiguration.getCommandExecutorTxRequired().execute(new Command<Void>() {
+            @Override
+            public Void execute(CommandContext commandContext) {
+              VariableInstanceEntity variable = VariableInstanceEntity.create("myVar",
+                  Variables.stringValue("myValue"), false);
+              variable.setTaskId(nonExistingTaskId);
+              VariableInstanceEntity.insert(variable);
+              return null;
+            }
+          })
+      ).isInstanceOf(ProcessEngineException.class)
+       .hasMessageContaining("Task with id 'non-existing-task-id' does not exist");
+    } finally {
+      // restore default
+      processEngineConfiguration.setCheckVariableTaskId(false);
+    }
   }
 }

--- a/engine/src/test/java/org/cibseven/bpm/engine/test/api/runtime/VariableInTransactionTest.java
+++ b/engine/src/test/java/org/cibseven/bpm/engine/test/api/runtime/VariableInTransactionTest.java
@@ -107,7 +107,7 @@ public class VariableInTransactionTest extends PluggableProcessEngineTest {
             }
           })
       ).isInstanceOf(ProcessEngineException.class)
-       .hasMessageContaining("Task with id 'non-existing-task-id' does not exist");
+       .hasMessageContaining("Task with id 'non-existing-task-id' doesn't exist or it is already completed");
     } finally {
       // restore default
       processEngineConfiguration.setCheckVariableTaskId(false);


### PR DESCRIPTION
A new engine option checkVariableTaskId is added, and when it is set to true then the engine will validate that the task Id, referenced by the variable, is not yet deleted (to prevents orphaned task variable references).