### PR TITLE
fix(engine): do not fail on dates that were filled in other tasks

### DIFF
--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/form/type/DateFormType.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/form/type/DateFormType.java
@@ -94,6 +94,9 @@ public class DateFormType extends AbstractFormFieldType {
     if (propertyValue==null || "".equals(propertyValue)) {
       return null;
     }
+    if (propertyValue instanceof Date) {
+      return propertyValue;
+    }
     try {
       return dateFormat.parseObject(propertyValue.toString());
     } catch (ParseException e) {


### PR DESCRIPTION
When you have process definition in which you first define a date in one task and then wants to use that value as default value in another task it results to an unhandled exception in REST API and also in old and new tasklist.

Replication:
1. download attached process definition [cibseven-date-poc.bpmn.xml](https://github.com/user-attachments/files/28023463/cibseven-date-poc.bpmn.xml)
1. remove `.xml` extension, added just to be able to upload it directly to Github
1. upload it to CIB seven
1. start new process instance
1. open task `date without default` in tasklist, fill whatever date and complete the  task
1. open task `date filled in previous step` results to an error and no field is shown

This change fixes the behavior and in the last step date is properly shown.
It was opened for Camunda a long time ago, but closed due to inactivity: https://github.com/camunda/camunda-bpm-platform/pull/332