### PR TITLE
fix(agent-connector): make default LLM model operator-overridable via sys-prop / env-var (CIB7-1415)

### DIFF
--- a/connect/ai-agent/src/main/java/org/cibseven/connect/ai/agent/AgentConnectorConstants.java
+++ b/connect/ai-agent/src/main/java/org/cibseven/connect/ai/agent/AgentConnectorConstants.java
@@ -21,8 +21,57 @@ package org.cibseven.connect.ai.agent;
  */
 public final class AgentConnectorConstants {
 
-  /** Default OpenAI-compatible model used when no {@code model} input parameter is provided. */
+  /**
+   * Hard-coded fallback model used when no {@code model} input parameter is set on
+   * the BPMN activity <em>and</em> the platform operator has not configured an
+   * override via {@link #DEFAULT_MODEL_PROPERTY} or {@link #DEFAULT_MODEL_ENV_VAR}.
+   *
+   * <p>Operators set their organisation-wide default through one of:
+   * <ul>
+   *   <li>JVM system property {@value #DEFAULT_MODEL_PROPERTY}
+   *       (e.g. {@code -Dcibseven.connect.ai-agent.defaultModel=<provider-model>}),</li>
+   *   <li>environment variable {@value #DEFAULT_MODEL_ENV_VAR},</li>
+   *   <li>or, in the run distro, the commented YAML stanza under
+   *       {@code cibseven.connect.ai-agent} in {@code default.yml}.</li>
+   * </ul>
+   *
+   * <p>Resolution order is implemented by {@link #resolveDefaultModel()}.
+   */
   public static final String DEFAULT_MODEL = "gpt-5.4-nano";
+
+  /**
+   * JVM system property that overrides {@link #DEFAULT_MODEL} for the deployment.
+   * Wins over {@link #DEFAULT_MODEL_ENV_VAR} when both are set.
+   */
+  public static final String DEFAULT_MODEL_PROPERTY = "cibseven.connect.ai-agent.defaultModel";
+
+  /** Environment-variable fallback for {@link #DEFAULT_MODEL_PROPERTY}. */
+  public static final String DEFAULT_MODEL_ENV_VAR = "CIBSEVEN_CONNECT_AI_AGENT_DEFAULT_MODEL";
+
+  /**
+   * Environment-variable lookup seam. Defaults to {@link System#getenv(String)};
+   * tests replace it to simulate env vars without spawning a new JVM. Always
+   * restore to {@code System::getenv} after the test.
+   */
+  static java.util.function.Function<String, String> ENV_READER = System::getenv;
+
+  /**
+   * Resolves the deployment-wide default model from
+   * {@link #DEFAULT_MODEL_PROPERTY} → {@link #DEFAULT_MODEL_ENV_VAR} →
+   * {@link #DEFAULT_MODEL}. Empty / blank values are treated as unset so an
+   * operator can re-enable the hard-coded fallback by clearing the override.
+   */
+  public static String resolveDefaultModel() {
+    String fromSys = System.getProperty(DEFAULT_MODEL_PROPERTY);
+    if (fromSys != null && !fromSys.trim().isEmpty()) {
+      return fromSys.trim();
+    }
+    String fromEnv = ENV_READER.apply(DEFAULT_MODEL_ENV_VAR);
+    if (fromEnv != null && !fromEnv.trim().isEmpty()) {
+      return fromEnv.trim();
+    }
+    return DEFAULT_MODEL;
+  }
 
   /** Default base URL for the OpenAI-compatible API endpoint. */
   public static final String DEFAULT_BASE_URL = "https://api.openai.com/v1";

--- a/connect/ai-agent/src/main/java/org/cibseven/connect/ai/agent/impl/AgentRequestImpl.java
+++ b/connect/ai-agent/src/main/java/org/cibseven/connect/ai/agent/impl/AgentRequestImpl.java
@@ -232,7 +232,7 @@ public class AgentRequestImpl extends AbstractConnectorRequest<AgentResponse> im
   @Override
   public String getModel() {
     String model = getRequestParameter(AgentConnector.PARAM_NAME_MODEL);
-    return (model != null) ? model : AgentConnectorConstants.DEFAULT_MODEL;
+    return (model != null) ? model : AgentConnectorConstants.resolveDefaultModel();
   }
 
   @Override

--- a/connect/ai-agent/src/test/java/org/cibseven/connect/ai/agent/AgentRequestTest.java
+++ b/connect/ai-agent/src/test/java/org/cibseven/connect/ai/agent/AgentRequestTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.cibseven.connect.ai.agent.impl.AgentConnectorImpl;
 import org.cibseven.connect.ai.agent.impl.AgentRequestImpl;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -30,6 +31,14 @@ public class AgentRequestTest {
   @Before
   public void setUp() {
     connector = new AgentConnectorImpl();
+    System.clearProperty(AgentConnectorConstants.DEFAULT_MODEL_PROPERTY);
+    AgentConnectorConstants.ENV_READER = System::getenv;
+  }
+
+  @After
+  public void tearDown() {
+    System.clearProperty(AgentConnectorConstants.DEFAULT_MODEL_PROPERTY);
+    AgentConnectorConstants.ENV_READER = System::getenv;
   }
 
   @Test
@@ -142,6 +151,39 @@ public class AgentRequestTest {
   public void shouldTreatExplicitNullPersistChatLogAsUnset() {
     AgentRequest request = connector.createRequest().persistChatLog(null);
     assertThat(request.getPersistChatLog()).isNull();
+  }
+
+  // ── Default-model resolution (CIB7-1415) ───────────────────────────────────
+
+  @Test
+  public void shouldUseSystemPropertyOverrideForDefaultModel() {
+    System.setProperty(AgentConnectorConstants.DEFAULT_MODEL_PROPERTY, "operator-pinned-model");
+    AgentRequest request = connector.createRequest();
+    assertThat(request.getModel()).isEqualTo("operator-pinned-model");
+  }
+
+  @Test
+  public void shouldFallBackToEnvVarWhenSystemPropertyUnset() {
+    AgentConnectorConstants.ENV_READER = name ->
+        AgentConnectorConstants.DEFAULT_MODEL_ENV_VAR.equals(name) ? "env-pinned-model" : null;
+    AgentRequest request = connector.createRequest();
+    assertThat(request.getModel()).isEqualTo("env-pinned-model");
+  }
+
+  @Test
+  public void shouldPreferSystemPropertyOverEnvVarForDefaultModel() {
+    System.setProperty(AgentConnectorConstants.DEFAULT_MODEL_PROPERTY, "sys-prop-wins");
+    AgentConnectorConstants.ENV_READER = name ->
+        AgentConnectorConstants.DEFAULT_MODEL_ENV_VAR.equals(name) ? "env-loses" : null;
+    AgentRequest request = connector.createRequest();
+    assertThat(request.getModel()).isEqualTo("sys-prop-wins");
+  }
+
+  @Test
+  public void shouldTreatBlankSystemPropertyAsUnset() {
+    System.setProperty(AgentConnectorConstants.DEFAULT_MODEL_PROPERTY, "   ");
+    AgentRequest request = connector.createRequest();
+    assertThat(request.getModel()).isEqualTo(AgentConnectorConstants.DEFAULT_MODEL);
   }
 
 }

--- a/distro/run/assembly/resources/default.yml
+++ b/distro/run/assembly/resources/default.yml
@@ -76,6 +76,19 @@ logging:
     root: INFO
 
 cibseven:
+  # AI Agent connector — operator-facing overrides.
+  #
+  # The connector reads JVM system properties (and environment-variable
+  # fallbacks), not YAML keys. To override the default LLM model used when
+  # the BPMN `model` input is omitted, set ONE of the following at startup:
+  #
+  #   JVM arg:  -Dcibseven.connect.ai-agent.defaultModel=<provider-model>
+  #   Env var:  CIBSEVEN_CONNECT_AI_AGENT_DEFAULT_MODEL=<provider-model>
+  #
+  # If neither is set, the connector falls back to the hard-coded default
+  # `gpt-5.4-nano`. See CIB7-1415 for the full list of override hooks
+  # (chat-log opt-out, content redaction, default model).
+
   webclient:
     modeler:
       enabled: true

--- a/distro/run4/assembly/resources/default.yml
+++ b/distro/run4/assembly/resources/default.yml
@@ -76,6 +76,19 @@ logging:
     root: INFO
 
 cibseven:
+  # AI Agent connector — operator-facing overrides.
+  #
+  # The connector reads JVM system properties (and environment-variable
+  # fallbacks), not YAML keys. To override the default LLM model used when
+  # the BPMN `model` input is omitted, set ONE of the following at startup:
+  #
+  #   JVM arg:  -Dcibseven.connect.ai-agent.defaultModel=<provider-model>
+  #   Env var:  CIBSEVEN_CONNECT_AI_AGENT_DEFAULT_MODEL=<provider-model>
+  #
+  # If neither is set, the connector falls back to the hard-coded default
+  # `gpt-5.4-nano`. See CIB7-1415 for the full list of override hooks
+  # (chat-log opt-out, content redaction, default model).
+
   webclient:
     modeler:
       enabled: true


### PR DESCRIPTION
## Summary

- When the BPMN activity omits the `model` input, the connector fell through to a hard-coded `gpt-5.4-nano` constant — a speculative placeholder that does not exist at any provider, so deploys relying on the default failed with an opaque 404 from the LLM API.
- Keep `gpt-5.4-nano` as the hard-coded fallback (no behavioural change for deployments that pin nothing) and add an operator-facing override knob in the same shape as the existing `chatLogVariable.enabled` and `redactContent` flags.
- Resolution order is sys-prop → env-var → fallback (`AgentConnectorConstants.resolveDefaultModel`).
- The Spring-Boot YAML → `System.getProperty` bridge is intentionally out of scope (decided 2026-05-25 — chat record in CIB7-1415); a future ticket can add a `@ConfigurationProperties` + `@PostConstruct` bridge in the run distro if customer demand surfaces.

Closes the §5.5 finding from the [PR #325 code review](https://helpdesk.cib.de/browse/CIB7-1412) ([CIB7-1415](https://helpdesk.cib.de/browse/CIB7-1415)).

## How to use

Launch CIB seven Run with one of:

```bash
# JVM arg
java -Dcibseven.connect.ai-agent.defaultModel=<provider-model> ...

# or environment variable
CIBSEVEN_CONNECT_AI_AGENT_DEFAULT_MODEL=<provider-model> java ...
```

If neither is set, the connector keeps using the hard-coded `gpt-5.4-nano` fallback exactly as before this change.

## Files changed

- `connect/ai-agent/src/main/java/org/cibseven/connect/ai/agent/AgentConnectorConstants.java` — `DEFAULT_MODEL` kept, new `DEFAULT_MODEL_PROPERTY` / `DEFAULT_MODEL_ENV_VAR` constants, package-private `ENV_READER` test seam, `resolveDefaultModel()` helper with blank-as-unset semantics.
- `connect/ai-agent/src/main/java/org/cibseven/connect/ai/agent/impl/AgentRequestImpl.java` — `getModel()` falls back to `resolveDefaultModel()` instead of the bare constant.
- `distro/run/assembly/resources/default.yml`, `distro/run4/assembly/resources/default.yml` — documentation comment under `cibseven:` describing the JVM-arg / env-var override forms and the hard-coded fallback. No functional change to defaults.
- `connect/ai-agent/src/test/java/org/cibseven/connect/ai/agent/AgentRequestTest.java` — `@Before` / `@After` reset the sys-prop and `ENV_READER` seam; 4 new tests cover sys-prop override, env-var fallback, sys-prop precedence over env-var, and blank-whitespace handling.

## Test plan

- [x] `mvn -B -f connect/ai-agent/pom.xml clean test` — 289 tests pass (4 new in `AgentRequestTest`).
- [ ] Smoke test on a real engine: launch CIB seven Run with `-Dcibseven.connect.ai-agent.defaultModel=gpt-5.4` and confirm the chat-log audit variable reports `"model": "gpt-5.4"` instead of `"model": "gpt-5.4-nano"`.
- [ ] Smoke test the env-var path: `CIBSEVEN_CONNECT_AI_AGENT_DEFAULT_MODEL=gpt-5.4 java -jar ...`.
- [ ] Smoke test the fallback: launch with neither override set, confirm the chat log still shows `gpt-5.4-nano`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)