### PR TITLE
fix(agent-connector): cap ProcessStarterTool maxRetries and pollIntervalMillis server-side (CIB7-1413)

### DIFF
--- a/connect/ai-agent/src/main/java/org/cibseven/connect/ai/agent/impl/ProcessStarterTool.java
+++ b/connect/ai-agent/src/main/java/org/cibseven/connect/ai/agent/impl/ProcessStarterTool.java
@@ -58,6 +58,29 @@ import dev.langchain4j.agent.tool.Tool;
  * {@link ProcessStarterToolContext}, populated by {@link AgentConnectorImpl}
  * from {@code IdentityService.getCurrentAuthentication()} at the start of the
  * connector invocation.
+ *
+ * <h3>Worst-case wait per call</h3>
+ * The LLM picks the {@code maxRetries} and {@code pollIntervalMillis}
+ * arguments, so without server-side clamping a single tool invocation could
+ * occupy a {@code JobExecutor} worker for an arbitrarily long time. To keep
+ * a single agent activity bounded, the values are hard-capped at
+ * {@value #MAX_RETRIES_CEILING} retries and {@value #MAX_POLL_INTERVAL_MILLIS_CEILING}
+ * ms per poll regardless of what the LLM passes (worst case ≈
+ * {@code MAX_RETRIES_CEILING × MAX_POLL_INTERVAL_MILLIS_CEILING} ms of
+ * {@code Thread.sleep} inside the connector — currently 100 s). The clamp is
+ * applied silently from the LLM's point of view; a DEBUG log is emitted on the
+ * server when the request exceeds either ceiling so operators can spot
+ * unusually long polls without flooding the audit stream.
+ *
+ * <h3>High-throughput deployments</h3>
+ * Even with the ceilings above, a tool call can monopolise a
+ * {@code JobExecutor} worker for up to ~{@code 100 s}. Deployments that need
+ * to keep agent activities off the engine's command-transaction critical
+ * path should model the BPMN such that the agent runs as an asynchronous
+ * service task (e.g. an external-task topic served by a dedicated worker
+ * pool) rather than a synchronous engine connector — at that point the
+ * blocking polling inside this tool no longer competes with regular process
+ * work for {@code JobExecutor} slots.
  */
 public class ProcessStarterTool {
 
@@ -68,6 +91,22 @@ public class ProcessStarterTool {
 
     /** Default delay between polls when the caller does not supply {@code pollIntervalMillis}. */
     static final long DEFAULT_POLL_INTERVAL_MILLIS = 2000L;
+
+    /**
+     * Hard upper bound for {@code maxRetries}. Values above the ceiling are
+     * clamped down so a single agent activity cannot occupy a
+     * {@code JobExecutor} worker for an arbitrary number of polls. See the
+     * class Javadoc for the worst-case bound.
+     */
+    static final int MAX_RETRIES_CEILING = 20;
+
+    /**
+     * Hard upper bound for {@code pollIntervalMillis}. Values above the
+     * ceiling are clamped down so a single poll cannot park the worker for
+     * an arbitrarily long {@code Thread.sleep}. See the class Javadoc for
+     * the worst-case bound.
+     */
+    static final long MAX_POLL_INTERVAL_MILLIS_CEILING = 5000L;
 
     /**
      * Dedicated executor for engine calls. A cached daemon-thread pool is used
@@ -95,18 +134,20 @@ public class ProcessStarterTool {
             + "'ended' (true once the process is no longer running), 'attempts' (number of polls "
             + "performed) and 'outputs' (process variables whose names start with the given "
             + "prefix). Use this tool when you need to start a process and react to its result; "
-            + "do not orchestrate your own polling loop on the LLM side.")
+            + "do not orchestrate your own polling loop on the LLM side. Server-side caps apply: "
+            + "maxRetries is clamped to 20 and pollIntervalMillis is clamped to 5000 ms regardless "
+            + "of the values you pass.")
     public Map<String, Object> runProcessByKey(
             @P("Process definition key (e.g. mcpProcess_hello)") String key,
             @P("Process variables to pass at start; may be empty") Map<String, Object> variables,
             @P("Prefix used to filter output variables (e.g. 'out_'); pass an empty string to return all variables") String outputPrefix,
             @P("Maximum number of polls to perform after starting the process before giving up. "
-                    + "Omit or pass null to use the default of 5 retries.") Integer maxRetries,
+                    + "Omit or pass null to use the default of 5 retries. Values above 20 are clamped to 20.") Integer maxRetries,
             @P("Milliseconds to wait between polls (e.g. 3000 for a 3-second interval). "
-                    + "Omit or pass null to use the default of 2000 ms.") Long pollIntervalMillis) {
+                    + "Omit or pass null to use the default of 2000 ms. Values above 5000 are clamped to 5000.") Long pollIntervalMillis) {
         String prefix = outputPrefix != null ? outputPrefix : "";
-        int retries = Math.max(0, maxRetries != null ? maxRetries : DEFAULT_MAX_RETRIES);
-        long interval = Math.max(0L, pollIntervalMillis != null ? pollIntervalMillis : DEFAULT_POLL_INTERVAL_MILLIS);
+        int retries = clampMaxRetries(maxRetries != null ? maxRetries : DEFAULT_MAX_RETRIES);
+        long interval = clampPollIntervalMillis(pollIntervalMillis != null ? pollIntervalMillis : DEFAULT_POLL_INTERVAL_MILLIS);
 
         LOG.debug("runProcessByKey: key='{}', retries={}, interval={}ms", key, retries, interval);
 
@@ -220,6 +261,33 @@ public class ProcessStarterTool {
             // Audit publishing must never break the tool itself.
             LOG.debug("Could not publish tool audit record: {}", e.toString());
         }
+    }
+
+    /**
+     * Clamps the requested retry budget into {@code [0, MAX_RETRIES_CEILING]}.
+     * Logs at DEBUG when the request is above the ceiling so operators can
+     * notice runaway LLM-supplied values without flooding the audit stream.
+     */
+    static int clampMaxRetries(int requested) {
+        if (requested > MAX_RETRIES_CEILING) {
+            LOG.debug("maxRetries={} exceeds ceiling, clamped to {}", requested, MAX_RETRIES_CEILING);
+            return MAX_RETRIES_CEILING;
+        }
+        return Math.max(0, requested);
+    }
+
+    /**
+     * Clamps the requested poll interval into {@code [0, MAX_POLL_INTERVAL_MILLIS_CEILING]}.
+     * Logs at DEBUG when the request is above the ceiling so operators can
+     * notice runaway LLM-supplied values without flooding the audit stream.
+     */
+    static long clampPollIntervalMillis(long requested) {
+        if (requested > MAX_POLL_INTERVAL_MILLIS_CEILING) {
+            LOG.debug("pollIntervalMillis={} exceeds ceiling, clamped to {}",
+                    requested, MAX_POLL_INTERVAL_MILLIS_CEILING);
+            return MAX_POLL_INTERVAL_MILLIS_CEILING;
+        }
+        return Math.max(0L, requested);
     }
 
     /**

--- a/connect/ai-agent/src/main/java/org/cibseven/connect/ai/agent/impl/ProcessStarterTool.java
+++ b/connect/ai-agent/src/main/java/org/cibseven/connect/ai/agent/impl/ProcessStarterTool.java
@@ -72,15 +72,36 @@ import dev.langchain4j.agent.tool.Tool;
  * server when the request exceeds either ceiling so operators can spot
  * unusually long polls without flooding the audit stream.
  *
+ * <h3>Async-before / async-after on the agent task</h3>
+ * Even with the ceilings above, a tool call can park the connector for up to
+ * ~{@code 100 s}. If the agent service task is modelled <em>synchronously</em>
+ * (no {@code camunda:asyncBefore} / {@code camunda:asyncAfter}), all of that
+ * blocking polling runs inside the parent command transaction — and any
+ * variable the agent or its tools write (the per-activity chat-log audit
+ * variable, the {@code agentOutput_aiMeta} Art. 50(2) marker, the sub-process
+ * {@code processInstanceId} from this tool) is held inside that transaction.
+ * When the agent runs longer than the engine's command-transaction timeout
+ * the transaction rolls back, the activity goes into an incident, and the
+ * audit variables are not visible from cockpit even though the side-effects
+ * (sub-processes started via this tool, MCP server calls) have already
+ * committed independently.
+ *
+ * <p>To avoid that, the bundled {@code cibseven-ai-agent.json} element
+ * template forces {@code camunda:asyncBefore="true"} and
+ * {@code camunda:asyncAfter="true"} on the service task via {@code Hidden}
+ * properties — the flags are not modeler-overridable from the template UI.
+ * With async-before, the parent process state commits before the agent
+ * task starts and the JobExecutor picks the task up on a fresh transaction;
+ * with async-after, the agent's output variables commit before the next
+ * sequence flow runs, so they are observable as soon as the agent finishes
+ * a turn — independent of how long the rest of the process takes.
+ *
  * <h3>High-throughput deployments</h3>
- * Even with the ceilings above, a tool call can monopolise a
- * {@code JobExecutor} worker for up to ~{@code 100 s}. Deployments that need
- * to keep agent activities off the engine's command-transaction critical
- * path should model the BPMN such that the agent runs as an asynchronous
- * service task (e.g. an external-task topic served by a dedicated worker
- * pool) rather than a synchronous engine connector — at that point the
- * blocking polling inside this tool no longer competes with regular process
- * work for {@code JobExecutor} slots.
+ * On deployments with very small JobExecutor pools, even the async-bracketed
+ * agent task can compete with regular process work. Such deployments should
+ * model the agent as an external-task topic served by a dedicated worker
+ * pool — the polling inside this tool then no longer competes with regular
+ * process work for {@code JobExecutor} slots at all.
  */
 public class ProcessStarterTool {
 

--- a/connect/ai-agent/src/main/resources/element-templates/cibseven-ai-agent.json
+++ b/connect/ai-agent/src/main/resources/element-templates/cibseven-ai-agent.json
@@ -3,7 +3,7 @@
   "name": "CIB seven - AI Agent",
   "id": "org.cibseven.connect.ai.agent",
   "version": 1,
-  "description": "Element template for the cibseven-ai-agent connector.",
+  "description": "Element template for the cibseven-ai-agent connector. The service task is forced to camunda:asyncBefore=\"true\" and camunda:asyncAfter=\"true\" so the agent runs on a JobExecutor thread and its audit variables (per-activity chat log, agentOutput_aiMeta) commit incrementally — without this the parent command transaction holds them until the (potentially long) LLM call finishes, and a timeout would roll them back together with the activity.",
   "icon": {
     "contents": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTkuNTAwMSAxLjAwMDAxTDYuODQzODUgNi44NDM3NkwxLjAwMDEgOS41MDAwMUw2Ljg0Mzg1IDEyLjE1NjNMOS41MDAxIDE4TDEyLjE1NjMgMTIuMTU2M0wxOC4wMDAxIDkuNTAwMDFMMTIuMTU2MyA2Ljg0Mzc2IiBmaWxsPSIjRTExRTE5Ii8+CjxwYXRoIGQ9Ik0xOCAxM0wxNi40Mzc1IDE2LjQzNzVMMTMgMThMMTYuNDM3NSAxOS41NjI1TDE4IDIzTDE5LjU2MjUgMTkuNTYyNUwyMyAxOEwxOS41NjI1IDE2LjQzNzUiIGZpbGw9IiMwRjIxMzMiLz4KPC9zdmc+Cg=="
   },
@@ -18,7 +18,24 @@
     { "id": "memory", "label": "Memory" },
     { "id": "rag",    "label": "RAG"    }
   ],
-  "properties": [],
+  "properties": [
+    {
+      "type": "Hidden",
+      "value": "true",
+      "binding": {
+        "type": "property",
+        "name": "camunda:asyncBefore"
+      }
+    },
+    {
+      "type": "Hidden",
+      "value": "true",
+      "binding": {
+        "type": "property",
+        "name": "camunda:asyncAfter"
+      }
+    }
+  ],
   "scopes": [
     {
       "type": "camunda:Connector",

--- a/connect/ai-agent/src/main/resources/element-templates/cibseven-knowledge-ingestor.json
+++ b/connect/ai-agent/src/main/resources/element-templates/cibseven-knowledge-ingestor.json
@@ -3,7 +3,7 @@
   "name": "CIB seven - Knowledge Ingestor",
   "id": "org.cibseven.connect.ai.agent.knowledge-ingestor",
   "version": 1,
-  "description": "Element template for the cibseven-knowledge-ingestor connector. Embeds text content into a pgvector knowledge base for later RAG retrieval by the AI Agent.",
+  "description": "Element template for the cibseven-knowledge-ingestor connector. Embeds text content into a pgvector knowledge base for later RAG retrieval by the AI Agent. The service task is forced to camunda:asyncBefore=\"true\" and camunda:asyncAfter=\"true\" so chunking + embedding (which can take seconds for large content) run on a JobExecutor thread instead of inside the parent command transaction.",
   "icon": {
     "contents": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTIgMjFWMTBMMTEgMTJWMjNMMiAyMVoiIGZpbGw9IiMwRjIxMzMiLz4KPHBhdGggZD0iTTIyIDIxVjEwTDEzIDEyVjIzTDIyIDIxWiIgZmlsbD0iIzBGMjEzMyIvPgo8cGF0aCBkPSJNMTAuNDI1IDQuNDI1TDEyIDFMMTMuNTYyNSA0LjQyNUwxNyA2TDEzLjU2MjUgNy41NjI1TDEyIDExTDEwLjQyNSA3LjU2MjVMNyA2TDEwLjQyNSA0LjQyNVoiIGZpbGw9IiNFMTFFMTkiLz4KPC9zdmc+Cg=="
   },
@@ -17,7 +17,24 @@
     { "id": "embedding", "label": "Embedding"  },
     { "id": "pgvector",  "label": "PostgreSQL" }
   ],
-  "properties": [],
+  "properties": [
+    {
+      "type": "Hidden",
+      "value": "true",
+      "binding": {
+        "type": "property",
+        "name": "camunda:asyncBefore"
+      }
+    },
+    {
+      "type": "Hidden",
+      "value": "true",
+      "binding": {
+        "type": "property",
+        "name": "camunda:asyncAfter"
+      }
+    }
+  ],
   "scopes": [
     {
       "type": "camunda:Connector",

--- a/connect/ai-agent/src/test/java/org/cibseven/connect/ai/agent/impl/ProcessStarterToolTest.java
+++ b/connect/ai-agent/src/test/java/org/cibseven/connect/ai/agent/impl/ProcessStarterToolTest.java
@@ -428,6 +428,86 @@ public class ProcessStarterToolTest {
     assertThat(ProcessStarterTool.DEFAULT_POLL_INTERVAL_MILLIS).isEqualTo(2000L);
   }
 
+  // ── Server-side caps (CIB7-1413) ─────────────────────────────────────────
+
+  @Test
+  public void ceilingsShouldMatchDocumentedValues() {
+    assertThat(ProcessStarterTool.MAX_RETRIES_CEILING).isEqualTo(20);
+    assertThat(ProcessStarterTool.MAX_POLL_INTERVAL_MILLIS_CEILING).isEqualTo(5000L);
+  }
+
+  @Test
+  public void clampMaxRetriesShouldFloorNegativesToZero() {
+    assertThat(ProcessStarterTool.clampMaxRetries(-7)).isZero();
+  }
+
+  @Test
+  public void clampMaxRetriesShouldPassThroughValuesWithinRange() {
+    assertThat(ProcessStarterTool.clampMaxRetries(0)).isZero();
+    assertThat(ProcessStarterTool.clampMaxRetries(7)).isEqualTo(7);
+    assertThat(ProcessStarterTool.clampMaxRetries(ProcessStarterTool.MAX_RETRIES_CEILING))
+        .isEqualTo(ProcessStarterTool.MAX_RETRIES_CEILING);
+  }
+
+  @Test
+  public void clampMaxRetriesShouldClampValuesAboveCeiling() {
+    assertThat(ProcessStarterTool.clampMaxRetries(100))
+        .isEqualTo(ProcessStarterTool.MAX_RETRIES_CEILING);
+    assertThat(ProcessStarterTool.clampMaxRetries(Integer.MAX_VALUE))
+        .isEqualTo(ProcessStarterTool.MAX_RETRIES_CEILING);
+  }
+
+  @Test
+  public void clampPollIntervalMillisShouldFloorNegativesToZero() {
+    assertThat(ProcessStarterTool.clampPollIntervalMillis(-1L)).isZero();
+  }
+
+  @Test
+  public void clampPollIntervalMillisShouldPassThroughValuesWithinRange() {
+    assertThat(ProcessStarterTool.clampPollIntervalMillis(0L)).isZero();
+    assertThat(ProcessStarterTool.clampPollIntervalMillis(2000L)).isEqualTo(2000L);
+    assertThat(ProcessStarterTool.clampPollIntervalMillis(
+            ProcessStarterTool.MAX_POLL_INTERVAL_MILLIS_CEILING))
+        .isEqualTo(ProcessStarterTool.MAX_POLL_INTERVAL_MILLIS_CEILING);
+  }
+
+  @Test
+  public void clampPollIntervalMillisShouldClampValuesAboveCeiling() {
+    assertThat(ProcessStarterTool.clampPollIntervalMillis(10_000L))
+        .isEqualTo(ProcessStarterTool.MAX_POLL_INTERVAL_MILLIS_CEILING);
+    assertThat(ProcessStarterTool.clampPollIntervalMillis(Long.MAX_VALUE))
+        .isEqualTo(ProcessStarterTool.MAX_POLL_INTERVAL_MILLIS_CEILING);
+  }
+
+  /**
+   * End-to-end guard that the ceiling is applied inside {@code runProcessByKey}
+   * — an LLM that passes {@code maxRetries=100} against a never-ending process
+   * must observe at most {@code MAX_RETRIES_CEILING} polls before bailing out
+   * with {@code ended=false}.
+   */
+  @Test
+  public void shouldClampMaxRetriesInsideRunProcessByKey() {
+    ProcessInstance starting = mockInstance("pi-cap", "def-cap", false, false);
+    when(runtimeService.startProcessInstanceByKey(eq("never"), any(Map.class))).thenReturn(starting);
+
+    // Process stays active forever — the loop must exit on the retry budget.
+    ProcessInstance stillActive = mockInstance("pi-cap", "def-cap", false, false);
+    ProcessInstanceQuery query = mock(ProcessInstanceQuery.class);
+    when(query.processInstanceId("pi-cap")).thenReturn(query);
+    when(query.singleResult()).thenReturn(stillActive);
+    when(runtimeService.createProcessInstanceQuery()).thenReturn(query);
+
+    when(runtimeService.getVariables("pi-cap")).thenReturn(new HashMap<>());
+
+    Map<String, Object> result = tool.runProcessByKey(
+        "never", null, "out_", /*maxRetries*/ 100, /*pollIntervalMillis*/ 0L);
+
+    assertThat(result.get("ended")).isEqualTo(false);
+    assertThat(result.get("attempts")).isEqualTo(ProcessStarterTool.MAX_RETRIES_CEILING);
+    // History query must NOT be hit on the not-ended path.
+    verify(historyService, never()).createHistoricProcessInstanceQuery();
+  }
+
   // ── Helpers ──────────────────────────────────────────────────────────────
 
   private static ProcessInstance mockInstance(String pid, String defId, boolean ended, boolean suspended) {


### PR DESCRIPTION
## Summary

Closes the §4.2 finding from the [PR #325 code review](https://helpdesk.cib.de/browse/CIB7-1412) ([CIB7-1413](https://helpdesk.cib.de/browse/CIB7-1413)). Two commits:

**Commit 1 — server-side caps on `ProcessStarterTool.runProcessByKey`**

The LLM picks `maxRetries` and `pollIntervalMillis`. Previous code only floored negatives, so a model could invent `maxRetries=100, pollIntervalMillis=10000` and occupy a `JobExecutor` worker for ~17 min of `Thread.sleep`. Add hard ceilings (`MAX_RETRIES_CEILING=20`, `MAX_POLL_INTERVAL_MILLIS_CEILING=5000` ms) and clamp via small package-private helpers. Worst-case wait per tool call now bounded to ~100 s. The `@Tool` description + parameter docs surfaced to the LLM name the ceilings explicitly so the model picks reasonable values up-front.

**Commit 2 — force `asyncBefore=true` and `asyncAfter=true` via Hidden in both element templates**

Reviewer's live reproduction confirmed the parent-incident path: an agent task running synchronously inside the parent command transaction holds the per-activity chat-log audit variable and the `agentOutput_aiMeta` Art. 50(2) marker until the LLM call finishes. If the command-transaction timeout fires first, the activity goes incident and the audit variables vanish even though the side-effects (sub-processes started via `ProcessStarterTool`, MCP server calls) have already committed in their own transactions.

Fix: force `camunda:asyncBefore="true"` and `camunda:asyncAfter="true"` on both `cibseven-ai-agent.json` and `cibseven-knowledge-ingestor.json` via top-level `Hidden` properties (modeler can't disable from the template UI — mirrors the existing `connectorId` lock-down). Rationale lives in each template's `description` so it's discoverable in the modeler.

## Behaviour change

| Input | Before | After |
|---|---|---|
| `maxRetries=null` | default `5` | default `5` (unchanged) |
| `maxRetries=-7` | floored to `0` | floored to `0` (unchanged) |
| `maxRetries=10` | `10` | `10` (unchanged) |
| `maxRetries=100` | `100` (~17 min worst case) | **`20`** (~100 s worst case) + DEBUG log |
| `pollIntervalMillis=10000` | `10000` | **`5000`** + DEBUG log |
| New agent task from element template | sync (no `camunda:async*` attributes) | **`asyncBefore=true` + `asyncAfter=true`** |
| Existing BPMNs already deployed | unaffected | unaffected |

## Files changed

- `connect/ai-agent/src/main/java/org/cibseven/connect/ai/agent/impl/ProcessStarterTool.java` — new ceiling constants, `clampMaxRetries` / `clampPollIntervalMillis` helpers, updated `@Tool` description / param docs (LLM-visible), expanded class Javadoc covering async-before/after rationale.
- `connect/ai-agent/src/main/resources/element-templates/cibseven-ai-agent.json` — top-level `Hidden` async flags, updated `description`.
- `connect/ai-agent/src/main/resources/element-templates/cibseven-knowledge-ingestor.json` — same.
- `connect/ai-agent/src/test/java/org/cibseven/connect/ai/agent/impl/ProcessStarterToolTest.java` — 8 new cases for caps.

## Test plan

- [x] `mvn -B -f connect/ai-agent/pom.xml clean test` — 293 tests pass.
- [x] Reviewer live repro confirmed async-before/after fixes the parent-incident path.
- [ ] Smoke test: agent activity asks LLM to call `runProcessByKey` with `maxRetries=100, pollIntervalMillis=10000`. Confirm audit log shows `attempts <= 20` and DEBUG line `pollIntervalMillis=10000 exceeds ceiling, clamped to 5000`.

## Out of scope (tracked separately)

A live reproduction also surfaced a **separate, deeper bug**: when the parent agent activity itself runs longer than `lockTimeInMillis` (default 5 min), the job lock expires and another `JobExecutor` worker re-acquires the same job — re-running the agent activity from scratch with no idempotency (new sub-process started, LLM tokens re-billed, chat log re-appended). Five iterations observed in a 25-minute run. Tracked as a new sub-task under [CIB7-1299](https://helpdesk.cib.de/browse/CIB7-1299); this PR doesn't try to fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
