### PR TITLE
feat(distro/tomcat): ship ai-agent connector as a default-on removable overlay (CIB7-1444)

### DIFF
--- a/distro/tomcat/ai-agent/pom.xml
+++ b/distro/tomcat/ai-agent/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.cibseven.bpm.tomcat</groupId>
+    <artifactId>cibseven-tomcat</artifactId>
+    <version>2.2.0-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+
+  <artifactId>cibseven-tomcat-ai-agent</artifactId>
+  <name>CIB seven - tomcat - AI Agent overlay</name>
+  <packaging>pom</packaging>
+
+  <properties>
+    <!-- generate a bom of compile time dependencies for the license book.
+    Note: Every compile time dependency will end up in the license book. Please
+    declare only dependencies that are actually needed -->
+    <skip-third-party-bom>false</skip-third-party-bom>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.cibseven.connect</groupId>
+      <artifactId>cibseven-connect-ai-agent</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <!-- already present in the tomcat lib via the connectors-all / connect-core dependencies -->
+        <exclusion>
+          <groupId>org.cibseven.connect</groupId>
+          <artifactId>cibseven-connect-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- collect the ai-agent connector + all its (LangChain4j / ONNX / pdfbox)
+           transitive runtime jars into target/dependency/, so the tomcat assembly
+           can drop the whole overlay onto the server classpath as one cohesive,
+           deletable set. The tomcat parent does not provide the run-distro
+           pluginManagement, so the execution is configured here directly. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-ai-agent-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <includeScope>runtime</includeScope>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <description>
+    Collects the cibseven-connect-ai-agent connector and its transitive AI
+    dependencies so the CIB seven Tomcat distribution can ship them as an
+    opt-in, default-on, deletable classpath overlay (see CIB7-1444 / CIB7-1299).
+  </description>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <organization>
+    <name>CIB seven</name>
+    <url>https://cibseven.org</url>
+  </organization>
+
+  <url>https://cibseven.org</url>
+
+  <developers>
+    <developer>
+      <id>CIB seven</id>
+      <name>CIB seven Community</name>
+      <organization>CIB seven</organization>
+      <organizationUrl>https://cibseven.org</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <url>https://github.com/cibseven/cibseven</url>
+    <connection>scm:git:git@github.com:cibseven/cibseven.git</connection>
+    <developerConnection>scm:git:git@github.com:cibseven/cibseven.git</developerConnection>
+    <tag>HEAD</tag>
+  </scm>
+
+  <issueManagement>
+    <system>GitHub Issues</system>
+    <url>https://github.com/cibseven/cibseven/issues</url>
+  </issueManagement>
+
+</project>

--- a/distro/tomcat/assembly/assembly.xml
+++ b/distro/tomcat/assembly/assembly.xml
@@ -121,6 +121,26 @@
     </dependencySet>
   </dependencySets>
 
+  <fileSets>
+    <!-- ai-agent connector overlay: the cibseven-tomcat-ai-agent module collects the
+         ai-agent connector + its LangChain4j/ONNX/pdfbox transitive jars into
+         target/dependency/. Dropping them into Tomcat's lib makes the connector
+         active by default (auto-loaded by the common classloader, registered via
+         the cibseven-connect SPI). It is shipped as a separable set so operators
+         who don't want AI can delete these jars and restore the non-invasive
+         behaviour described in CIB7-1299.
+
+         Only placed in server/apache-tomcat-*/lib — the actual runtime classpath
+         for both the standalone start-cibseven.sh (CATALINA_HOME=server/...) and
+         the docker image (which extracts only the server/ subtree). The root lib/
+         is a packaging artifact that nothing loads at runtime, so the heavy
+         (~200 MB) overlay is deliberately NOT duplicated there. -->
+    <fileSet>
+      <directory>../ai-agent/target/dependency/</directory>
+      <outputDirectory>server/apache-tomcat-${version.tomcat}/lib</outputDirectory>
+    </fileSet>
+  </fileSets>
+
   <files>
     <file>
       <source>src/README.txt</source>
@@ -176,6 +196,14 @@
     <file>
       <source>src/conf/Catalina/localhost/webapp.xml</source>
       <outputDirectory>server/apache-tomcat-${version.tomcat}/conf/Catalina/localhost/</outputDirectory>
+    </file>
+
+    <!-- empty directory operators drop their own element-template JSONs into;
+         referenced by the cibseven.webclient.modeler.templates.paths file: entry
+         in conf/Catalina/localhost/webapp.xml -->
+    <file>
+      <source>src/conf/element-templates/.gitkeep</source>
+      <outputDirectory>server/apache-tomcat-${version.tomcat}/conf/element-templates/</outputDirectory>
     </file>
       
     <file>

--- a/distro/tomcat/assembly/pom.xml
+++ b/distro/tomcat/assembly/pom.xml
@@ -149,6 +149,23 @@
       </exclusions>
     </dependency>
 
+    <!-- make sure the assembly runs after the ai-agent overlay module, which
+         collects the ai-agent connector + its AI deps into target/dependency/.
+         We don't want any of those jars on the assembly's own classpath here —
+         the assembly only consumes the pre-collected folder via a fileSet. -->
+    <dependency>
+      <groupId>org.cibseven.bpm.tomcat</groupId>
+      <artifactId>cibseven-tomcat-ai-agent</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
     <dependency>
       <groupId>org.cibseven.bpm</groupId>
       <artifactId>license-book</artifactId>

--- a/distro/tomcat/assembly/src/conf/Catalina/localhost/webapp.xml
+++ b/distro/tomcat/assembly/src/conf/Catalina/localhost/webapp.xml
@@ -11,6 +11,16 @@
         value="true"
         override="false" />
 
+    <!-- Element-template discovery for the modeler. Comma-separated -> bound to a
+         List<String>. classpath*: picks up bundled connector templates (e.g. the
+         ai-agent overlay JAR's /element-templates/*.json); the file: entry lets
+         operators drop their own JSONs into <tomcat>/conf/element-templates/
+         (${catalina.base} = ./ standalone, /camunda in docker). -->
+    <Parameter
+        name="cibseven.webclient.modeler.templates.paths"
+        value="classpath*:element-templates/*.json,file:${catalina.base}/conf/element-templates/*.json"
+        override="false" />
+
     <Parameter
         name="spring.datasource.jndi-name"
         value="java:comp/env/jdbc/ProcessEngine"

--- a/distro/tomcat/assembly/src/conf/element-templates/.gitkeep
+++ b/distro/tomcat/assembly/src/conf/element-templates/.gitkeep
@@ -1,0 +1,4 @@
+# Drop custom CIB seven modeler element-template JSON files into this directory.
+# They are discovered via cibseven.webclient.modeler.templates.paths
+# (file:${catalina.base}/conf/element-templates/*.json). This placeholder file
+# keeps the otherwise-empty directory under version control and in the distro.

--- a/distro/tomcat/pom.xml
+++ b/distro/tomcat/pom.xml
@@ -33,6 +33,7 @@
         <activeByDefault>true</activeByDefault>
       </activation>
       <modules>
+        <module>ai-agent</module>
         <module>assembly</module>
         <module>distro</module>
         <module>webapp-jakarta</module>


### PR DESCRIPTION
## What & why

Closes the gap where the `cibseven-connect-ai-agent` connector (CIB7-1299) shipped only in the **run** distribution. The Tomcat distro shipped http/soap but not ai-agent, so app-server customers couldn't use the agentic AI connector without hand-assembling jars.

This bundles the connector into the Tomcat distribution as an **opt-in overlay that is active by default but cleanly removable** — honoring CIB7-1299's non-invasive principle ("if the plugin JAR is absent, the engine behaves identically").

## Changes

- **New `cibseven-tomcat-ai-agent` module** (`distro/tomcat/ai-agent/`) collects the connector + its LangChain4j/ONNX/pdfbox transitive runtime jars into `target/dependency/` (mirrors `distro/run/modules/ai-agent`; `connect-core` excluded — already on the Tomcat classpath).
- **Assembly** drops the overlay into `server/apache-tomcat-*/lib` **only** — the real runtime classpath for both the standalone start script (`CATALINA_HOME=server/...`) and the docker image (which extracts only the `server/` subtree). The root `lib/` is a packaging artifact nothing loads, so the ~200 MB overlay is deliberately not duplicated there.
- **Modeler element-templates**: added `cibseven.webclient.modeler.templates.paths` to `webapp.xml` (consistent with PR #320's convention) — `classpath*:element-templates/*.json` for bundled connector templates + `file:${catalina.base}/conf/element-templates/*.json` for operator templates; ships an empty `conf/element-templates/` drop-in dir.

## Footprint note

The overlay is ~208 MB (onnxruntime + the all-minilm-l6-v2 embedding model dominate). It is active by default; delete the overlay jars to restore a no-AI boot. A companion PR in `cibseven-docker` adds an `AI_AGENT_ENABLED` env var to toggle it at container startup.

## Verification done

Built the Tomcat assembly: the 42-jar overlay lands in `server/apache-tomcat-11.0.22/lib/`, is absent from root `lib/`, `connectors-all` (http/soap) is untouched, and `webapp.xml` carries the templates paths. Runtime check still TODO: confirm `${catalina.base}` resolution + the modeler templates endpoint serving the ai-agent template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)