### PR TITLE
feat(distro/run): gate ai-agent connector to dev/default with an opt-in flag (CIB7-1447)

### DIFF
--- a/distro/run/assembly/assembly.xml
+++ b/distro/run/assembly/assembly.xml
@@ -133,11 +133,13 @@
       <directory>../modules/oauth2/target/dependency/</directory>
       <outputDirectory>internal/oauth2/</outputDirectory>
     </fileSet>
-    <!-- ai-agent ships into userlib so it is always on the engine classpath
-         and registers via the cibseven-connect SPI without requiring an opt-in flag -->
+    <!-- ai-agent ships into a dedicated userlib-ai/ folder (NOT the always-on
+         userlib/). run.sh adds it to the loader path only when the AI agent is
+         enabled: on by default in default/dev mode, off in production mode unless
+         the ai/agent flag or the AI_AGENT_ENABLED env var is set (CIB7-1447). -->
     <fileSet>
       <directory>../modules/ai-agent/target/dependency/</directory>
-      <outputDirectory>configuration/userlib/</outputDirectory>
+      <outputDirectory>configuration/userlib-ai/</outputDirectory>
     </fileSet>
     <!-- create empty resource folder -->
     <fileSet>

--- a/distro/run/assembly/resources/run.bat
+++ b/distro/run/assembly/resources/run.bat
@@ -66,6 +66,7 @@ SET optionalComponentChosen=false
 SET restChosen=false
 SET productionChosen=false
 SET detachProcess=false
+SET aiAgentChosen=false
 SET classPath=%PARENTDIR%configuration\userlib,%PARENTDIR%configuration\keystore
 SET configuration=%PARENTDIR%configuration\default.yml
 SET webclientProperties=%PARENTDIR%configuration\userlib\cibseven-webclient.properties
@@ -126,6 +127,10 @@ IF [%~1]==[--production] (
   SET configuration=%PARENTDIR%configuration\production.yml
 )
 
+IF [%~1]==[--ai] SET aiAgentChosen=true
+IF [%~1]==[--ai-agent] SET aiAgentChosen=true
+IF [%~1]==[--agent] SET aiAgentChosen=true
+
 IF [%~1]==[--detached] (
   SET detachProcess=true
 )
@@ -152,6 +157,20 @@ IF [%optionalComponentChosen%]==[false] (
   SET classPath=%WEBAPPS_PATH%,%REST_PATH%,!classPath!
 )
 setlocal disabledelayedexpansion
+
+REM AI Agent connector: shipped separately in configuration\userlib-ai and only
+REM added to the classpath when enabled (default mode on; --production off unless
+REM --ai / --agent or the AI_AGENT_ENABLED env var is set).
+SET aiAgentEnabled=true
+IF [%productionChosen%]==[true] SET aiAgentEnabled=false
+IF [%aiAgentChosen%]==[true] SET aiAgentEnabled=true
+IF NOT "x%AI_AGENT_ENABLED%"=="x" SET aiAgentEnabled=%AI_AGENT_ENABLED%
+IF [%aiAgentEnabled%]==[true] (
+  SET classPath=%PARENTDIR%configuration\userlib-ai,%classPath%
+  ECHO AI Agent connector enabled
+) ELSE (
+  ECHO AI Agent connector disabled
+)
 
 ECHO classpath: %classPath%
 
@@ -185,6 +204,7 @@ ECHO   --oauth2     - Enables the CIB seven Spring Security OAuth2 integration
 ECHO   --rest       - Enables the REST API
 ECHO   --example    - Enables the example application
 ECHO   --production - Applies the production.yaml configuration file
+ECHO   --ai         - Enables the AI Agent connector (on by default; off under --production unless set)
 ECHO   --detached   - Starts CIB seven Run as a detached process
 
 :End

--- a/distro/run/assembly/resources/run.sh
+++ b/distro/run/assembly/resources/run.sh
@@ -15,6 +15,7 @@ OPTIONS_HELP="Options:
   --rest       - Enables the REST API
   --example    - Enables the example application
   --production - Applies the production.yaml configuration file
+  --ai         - Enables the AI Agent connector (on by default; off under --production unless set)
   --detached   - Starts CIB seven Run as a detached process
 "
 
@@ -23,6 +24,7 @@ optionalComponentChosen=false
 restChosen=false
 productionChosen=false
 detachProcess=false
+aiAgentChosen=false
 classPath=$PARENTDIR/configuration/userlib/,$PARENTDIR/configuration/keystore/
 configuration=$PARENTDIR/configuration/default.yml
 
@@ -94,6 +96,9 @@ if [ "$1" = "start" ] ; then
       --production ) configuration=$PARENTDIR/configuration/production.yml
                      productionChosen=true
                      ;;
+      # the AI agent flag is orthogonal to the optional components above
+      --ai | --ai-agent | --agent ) aiAgentChosen=true
+                     ;;
       # the background flag shouldn't influence the optional component flags
       --detached )   detachProcess=true
                      echo CIB seven Run will start in the background. Use the shutdown.sh script to stop it
@@ -120,6 +125,28 @@ if [ "$1" = "start" ] ; then
       classPath=$EXAMPLE_PATH,$classPath
     fi
     classPath=$WEBAPPS_PATH,$REST_PATH,$classPath
+  fi
+
+  # AI Agent connector: shipped separately in configuration/userlib-ai/ and only
+  # added to the classpath when enabled. Enabled by default in default/dev mode,
+  # disabled under --production unless re-enabled with --ai / --agent. The
+  # AI_AGENT_ENABLED environment variable (true/false) overrides the above and is
+  # the control surface used by the docker image.
+  aiAgentEnabled=true
+  if [ "$productionChosen" = "true" ]; then
+    aiAgentEnabled=false
+  fi
+  if [ "$aiAgentChosen" = "true" ]; then
+    aiAgentEnabled=true
+  fi
+  if [ "x$AI_AGENT_ENABLED" != "x" ]; then
+    aiAgentEnabled=$AI_AGENT_ENABLED
+  fi
+  if [ "$aiAgentEnabled" = "true" ]; then
+    classPath=$PARENTDIR/configuration/userlib-ai/,$classPath
+    echo AI Agent connector enabled
+  else
+    echo AI Agent connector disabled
   fi
 
   echo classpath: $classPath

--- a/distro/run4/assembly/assembly.xml
+++ b/distro/run4/assembly/assembly.xml
@@ -133,11 +133,13 @@
       <directory>../modules/oauth2/target/dependency/</directory>
       <outputDirectory>internal/oauth2/</outputDirectory>
     </fileSet>
-    <!-- ai-agent ships into userlib so it is always on the engine classpath
-         and registers via the cibseven-connect SPI without requiring an opt-in flag -->
+    <!-- ai-agent ships into a dedicated userlib-ai/ folder (NOT the always-on
+         userlib/). run.sh adds it to the loader path only when the AI agent is
+         enabled: on by default in default/dev mode, off in production mode unless
+         the ai/agent flag or the AI_AGENT_ENABLED env var is set (CIB7-1447). -->
     <fileSet>
       <directory>../modules/ai-agent/target/dependency/</directory>
-      <outputDirectory>configuration/userlib/</outputDirectory>
+      <outputDirectory>configuration/userlib-ai/</outputDirectory>
     </fileSet>
     <!-- create empty resource folder -->
     <fileSet>

--- a/distro/run4/assembly/resources/run.bat
+++ b/distro/run4/assembly/resources/run.bat
@@ -66,6 +66,7 @@ SET optionalComponentChosen=false
 SET restChosen=false
 SET productionChosen=false
 SET detachProcess=false
+SET aiAgentChosen=false
 SET classPath=%PARENTDIR%configuration\userlib,%PARENTDIR%configuration\keystore
 SET configuration=%PARENTDIR%configuration\default.yml
 SET webclientProperties=%PARENTDIR%configuration\userlib\cibseven-webclient.properties
@@ -126,6 +127,10 @@ IF [%~1]==[--production] (
   SET configuration=%PARENTDIR%configuration\production.yml
 )
 
+IF [%~1]==[--ai] SET aiAgentChosen=true
+IF [%~1]==[--ai-agent] SET aiAgentChosen=true
+IF [%~1]==[--agent] SET aiAgentChosen=true
+
 IF [%~1]==[--detached] (
   SET detachProcess=true
 )
@@ -152,6 +157,20 @@ IF [%optionalComponentChosen%]==[false] (
   SET classPath=%WEBAPPS_PATH%,%REST_PATH%,!classPath!
 )
 setlocal disabledelayedexpansion
+
+REM AI Agent connector: shipped separately in configuration\userlib-ai and only
+REM added to the classpath when enabled (default mode on; --production off unless
+REM --ai / --agent or the AI_AGENT_ENABLED env var is set).
+SET aiAgentEnabled=true
+IF [%productionChosen%]==[true] SET aiAgentEnabled=false
+IF [%aiAgentChosen%]==[true] SET aiAgentEnabled=true
+IF NOT "x%AI_AGENT_ENABLED%"=="x" SET aiAgentEnabled=%AI_AGENT_ENABLED%
+IF [%aiAgentEnabled%]==[true] (
+  SET classPath=%PARENTDIR%configuration\userlib-ai,%classPath%
+  ECHO AI Agent connector enabled
+) ELSE (
+  ECHO AI Agent connector disabled
+)
 
 ECHO classpath: %classPath%
 
@@ -185,6 +204,7 @@ ECHO   --oauth2     - Enables the CIB seven Spring Security OAuth2 integration
 ECHO   --rest       - Enables the REST API
 ECHO   --example    - Enables the example application
 ECHO   --production - Applies the production.yaml configuration file
+ECHO   --ai         - Enables the AI Agent connector (on by default; off under --production unless set)
 ECHO   --detached   - Starts CIB seven Run as a detached process
 
 :End

--- a/distro/run4/assembly/resources/run.sh
+++ b/distro/run4/assembly/resources/run.sh
@@ -15,6 +15,7 @@ OPTIONS_HELP="Options:
   --rest       - Enables the REST API
   --example    - Enables the example application
   --production - Applies the production.yaml configuration file
+  --ai         - Enables the AI Agent connector (on by default; off under --production unless set)
   --detached   - Starts CIB seven Run as a detached process
 "
 
@@ -23,6 +24,7 @@ optionalComponentChosen=false
 restChosen=false
 productionChosen=false
 detachProcess=false
+aiAgentChosen=false
 classPath=$PARENTDIR/configuration/userlib/,$PARENTDIR/configuration/keystore/
 configuration=$PARENTDIR/configuration/default.yml
 
@@ -94,6 +96,9 @@ if [ "$1" = "start" ] ; then
       --production ) configuration=$PARENTDIR/configuration/production.yml
                      productionChosen=true
                      ;;
+      # the AI agent flag is orthogonal to the optional components above
+      --ai | --ai-agent | --agent ) aiAgentChosen=true
+                     ;;
       # the background flag shouldn't influence the optional component flags
       --detached )   detachProcess=true
                      echo CIB seven Run will start in the background. Use the shutdown.sh script to stop it
@@ -120,6 +125,28 @@ if [ "$1" = "start" ] ; then
       classPath=$EXAMPLE_PATH,$classPath
     fi
     classPath=$WEBAPPS_PATH,$REST_PATH,$classPath
+  fi
+
+  # AI Agent connector: shipped separately in configuration/userlib-ai/ and only
+  # added to the classpath when enabled. Enabled by default in default/dev mode,
+  # disabled under --production unless re-enabled with --ai / --agent. The
+  # AI_AGENT_ENABLED environment variable (true/false) overrides the above and is
+  # the control surface used by the docker image.
+  aiAgentEnabled=true
+  if [ "$productionChosen" = "true" ]; then
+    aiAgentEnabled=false
+  fi
+  if [ "$aiAgentChosen" = "true" ]; then
+    aiAgentEnabled=true
+  fi
+  if [ "x$AI_AGENT_ENABLED" != "x" ]; then
+    aiAgentEnabled=$AI_AGENT_ENABLED
+  fi
+  if [ "$aiAgentEnabled" = "true" ]; then
+    classPath=$PARENTDIR/configuration/userlib-ai/,$classPath
+    echo AI Agent connector enabled
+  else
+    echo AI Agent connector disabled
   fi
 
   echo classpath: $classPath


### PR DESCRIPTION
## What & why

In the **run** (and **run4**) distributions the ai-agent connector shipped in `configuration/userlib/`, which `run.sh` puts on `-Dloader.path` **unconditionally** — so the connector and its ~200 MB of LangChain4j/ONNX dependencies were active in **both** default and `--production` modes, with no way to turn them off. This gates the connector, honoring CIB7-1299's non-invasive principle.

## Behaviour

| Start | ai-agent |
|---|---|
| default / dev (`run.sh start`) | **on** |
| `--production` | **off** |
| `--production --ai` (or `--ai-agent` / `--agent`) | **on** |
| any mode + `AI_AGENT_ENABLED=true/false` | forced on/off (overrides the above) |

`AI_AGENT_ENABLED` is the same env var the Tomcat docker image uses (introduced in the companion docker PR cibseven-docker#33) — the run/run4 docker images inherit it and `run.sh` honors it, so no run-specific docker script change is needed.

## Changes (run + run4, kept in lockstep)

- `assembly.xml`: ship the ai-agent overlay into a dedicated `configuration/userlib-ai/` folder instead of the always-on `userlib/`.
- `run.sh` / `run.bat`: new `--ai` / `--ai-agent` / `--agent` flag + gating logic that adds `userlib-ai/` to the loader path only when enabled; `AI_AGENT_ENABLED` env override; help text updated.

## Verification done

- `bash -n` clean; gating logic simulated across all 5 scenarios (default→on, production→off, production+--ai→on, dev+env false→off, production+env true→on).
- Built both run and run4 assemblies: the 42-jar overlay lands in `configuration/userlib-ai/`, **none** of it in `userlib/`, and `userlib/` still carries h2/groovy + the webclient.properties path.

Runtime check still TODO: start `run.sh` in each mode and confirm the connector registers/doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)