### PR TITLE
refactor(distro/tomcat): load ai-agent overlay from lib-ai/ via common.loader (CIB7-1444)

### DIFF
--- a/distro/tomcat/assembly/assembly.xml
+++ b/distro/tomcat/assembly/assembly.xml
@@ -26,6 +26,8 @@
       <unpackOptions>
         <excludes>
           <exclude>**/conf/server.xml</exclude>
+          <!-- shipped customised below: adds lib-ai/ to common.loader -->
+          <exclude>**/conf/catalina.properties</exclude>
         </excludes>
       </unpackOptions>
       <unpack>true</unpack>
@@ -124,20 +126,21 @@
   <fileSets>
     <!-- ai-agent connector overlay: the cibseven-tomcat-ai-agent module collects the
          ai-agent connector + its LangChain4j/ONNX/pdfbox transitive jars into
-         target/dependency/. Dropping them into Tomcat's lib makes the connector
-         active by default (auto-loaded by the common classloader, registered via
-         the cibseven-connect SPI). It is shipped as a separable set so operators
-         who don't want AI can delete these jars and restore the non-invasive
-         behaviour described in CIB7-1299.
+         target/dependency/. They ship into a dedicated lib-ai/ folder (NOT the
+         always-loaded lib/) which the shipped conf/catalina.properties adds to the
+         common.loader — so the connector is on the same classloader as the engine
+         and registers via the cibseven-connect SPI, active by default.
 
-         Only placed in server/apache-tomcat-*/lib — the actual runtime classpath
-         for both the standalone start-cibseven.sh (CATALINA_HOME=server/...) and
-         the docker image (which extracts only the server/ subtree). The root lib/
-         is a packaging artifact that nothing loads at runtime, so the heavy
-         (~200 MB) overlay is deliberately NOT duplicated there. -->
+         Keeping it a separate folder makes it toggleable WITHOUT deleting jars:
+         the docker image strips the lib-ai tokens from common.loader when
+         AI_AGENT_ENABLED=false (see cibseven-tomcat.sh); standalone operators can
+         delete the lib-ai/ folder. This restores the non-invasive behaviour of
+         CIB7-1299. Only under server/apache-tomcat-* (the runtime classpath for
+         the standalone start script and the docker image, which extracts only the
+         server/ subtree); the root lib/ loads nothing, so it is not duplicated. -->
     <fileSet>
       <directory>../ai-agent/target/dependency/</directory>
-      <outputDirectory>server/apache-tomcat-${version.tomcat}/lib</outputDirectory>
+      <outputDirectory>server/apache-tomcat-${version.tomcat}/lib-ai</outputDirectory>
     </fileSet>
   </fileSets>
 
@@ -187,7 +190,16 @@
       <source>src/conf/server.xml</source>
       <outputDirectory>server/apache-tomcat-${version.tomcat}/conf/</outputDirectory>
     </file>
-    
+
+    <!-- customised catalina.properties: generated at build time = stock file from
+         the pinned Tomcat artifact + the lib-ai/ entry on common.loader (see the
+         dependency/antrun executions in pom.xml). Replaces the stock file excluded
+         from the tomcat unpack above; stays in sync with Tomcat upgrades. -->
+    <file>
+      <source>target/tomcat-conf/apache-tomcat-${version.tomcat}/conf/catalina.properties</source>
+      <outputDirectory>server/apache-tomcat-${version.tomcat}/conf/</outputDirectory>
+    </file>
+
     <file>
       <source>src/conf/bpm-platform.xml</source>
       <outputDirectory>server/apache-tomcat-${version.tomcat}/conf/</outputDirectory>

--- a/distro/tomcat/assembly/pom.xml
+++ b/distro/tomcat/assembly/pom.xml
@@ -187,6 +187,62 @@
 
   <build>
     <plugins>
+      <!-- Build-time generation of a customised catalina.properties.
+           We do NOT vendor a copy of the file (which would drift on Tomcat
+           upgrades). Instead we extract the STOCK catalina.properties out of the
+           pinned Tomcat artifact and append a single token to common.loader so the
+           ai-agent overlay in lib-ai/ is on the common classloader. On a Tomcat
+           bump the stock file is re-extracted automatically; we own only the
+           one-line delta. The assembly excludes the stock file from the unpack and
+           ships the generated one (see assembly.xml). -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>extract-stock-catalina-properties</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.apache.tomcat</groupId>
+                  <artifactId>tomcat</artifactId>
+                  <version>${version.tomcat}</version>
+                  <type>tar.gz</type>
+                  <includes>**/conf/catalina.properties</includes>
+                  <outputDirectory>${project.build.directory}/tomcat-conf</outputDirectory>
+                  <overWrite>true</overWrite>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-lib-ai-to-common-loader</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <replaceregexp
+                    file="${project.build.directory}/tomcat-conf/apache-tomcat-${version.tomcat}/conf/catalina.properties"
+                    match="^(common.loader=.*)$"
+                    replace="\1,&quot;${catalina.base}/lib-ai&quot;,&quot;${catalina.base}/lib-ai/*.jar&quot;"
+                    byline="true" />
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>


### PR DESCRIPTION
## What & why

Follow-up to the merged #346. That PR dropped the ai-agent jars **flat into `server/.../lib`**, which meant the docker image had to **delete the connector jar** to disable it. This reworks it so the overlay lives in a dedicated **`lib-ai/`** folder wired onto Tomcat's `common.loader`, so it can be toggled **non-destructively**.

## How

- **`assembly.xml`**: ai-agent overlay → `server/apache-tomcat-*/lib-ai` (was `lib`). The connector stays on the **same classloader as the engine** (common loader), so SPI registration is unchanged; active by default.
- **`catalina.properties` is generated at build time, not vendored.** Tomcat reads a single `catalina.properties` (no merge/include, and `common.loader` can't be set via `-D`), so we can't just drop in an "additional" file. To avoid drifting on Tomcat upgrades, the build **extracts the stock file from the pinned Tomcat artifact** (`maven-dependency-plugin unpack`) and **appends one `lib-ai` token to `common.loader`** (`antrun replaceregexp`). We own only the one-line delta; on a Tomcat bump the stock file is re-extracted automatically.

## Toggle (non-destructive)

- Standalone: delete the `lib-ai/` folder.
- Docker (companion PR cibseven-docker#33): when `AI_AGENT_ENABLED=false`, `sed` the `lib-ai` tokens out of `common.loader` — **no jars deleted**.

## Verification done

Built the assembly: 42-jar overlay in `lib-ai/` (none in `lib/`); shipped `catalina.properties` is the full 198-line stock Tomcat 11.0.22 file (verified via `jarsToSkip` marker) with only the `lib-ai` tokens appended to `common.loader`; the docker disable `sed` cleanly strips those tokens and leaves the stock entries intact.

Runtime check still TODO: boot Tomcat with/without the toggle and confirm the connector registers / doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)