### PR TITLE
feat(distro/wildfly): ship ai-agent connector as an optional JBoss module (CIB7-1445)

### DIFF
--- a/distro/wildfly/ai-agent/pom.xml
+++ b/distro/wildfly/ai-agent/pom.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.cibseven.bpm.wildfly</groupId>
+    <artifactId>cibseven-wildfly</artifactId>
+    <version>2.2.0-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+
+  <artifactId>cibseven-wildfly-ai-agent</artifactId>
+  <name>CIB seven - Wildfly - AI Agent module collector</name>
+  <packaging>pom</packaging>
+
+  <properties>
+    <!-- generate a bom of compile time dependencies for the license book.
+    Note: Every compile time dependency will end up in the license book. Please
+    declare only dependencies that are actually needed -->
+    <skip-third-party-bom>false</skip-third-party-bom>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.cibseven.connect</groupId>
+      <artifactId>cibseven-connect-ai-agent</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <!-- already its own WildFly module (org.cibseven.connect.cibseven-connect-core) -->
+        <exclusion>
+          <groupId>org.cibseven.connect</groupId>
+          <artifactId>cibseven-connect-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- Collect the ai-agent connector + its (LangChain4j / ONNX / pdfbox /
+           pgvector) transitive runtime jars into target/dependency/. The wildfly
+           modules build copies this folder into a single fat JBoss module and
+           generates a <resource-root> per jar. engine + jackson are provided (so
+           excluded by includeScope=runtime); connect-core is excluded above (it is
+           its own module); slf4j-api is provided by the org.slf4j WildFly module. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-ai-agent-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <includeScope>runtime</includeScope>
+              <!-- slf4j + jackson are provided by their own WildFly modules (the
+                   ai-agent module.xml depends on org.slf4j and the jackson slot);
+                   excluding the jars here avoids duplicate classes on the module
+                   classpath. LangChain pulls jackson transitively as compile scope,
+                   hence the explicit excludes. -->
+              <excludeArtifactIds>slf4j-api,jackson-databind,jackson-core,jackson-annotations</excludeArtifactIds>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <description>
+    Collects the cibseven-connect-ai-agent connector and its transitive AI
+    dependencies so the CIB seven WildFly distribution can ship them as a single
+    JBoss module, active by default and removable (see CIB7-1445 / CIB7-1299).
+  </description>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <organization>
+    <name>CIB seven</name>
+    <url>https://cibseven.org</url>
+  </organization>
+
+  <url>https://cibseven.org</url>
+
+  <developers>
+    <developer>
+      <id>CIB seven</id>
+      <name>CIB seven Community</name>
+      <organization>CIB seven</organization>
+      <organizationUrl>https://cibseven.org</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <url>https://github.com/cibseven/cibseven</url>
+    <connection>scm:git:git@github.com:cibseven/cibseven.git</connection>
+    <developerConnection>scm:git:git@github.com:cibseven/cibseven.git</developerConnection>
+    <tag>HEAD</tag>
+  </scm>
+
+  <issueManagement>
+    <system>GitHub Issues</system>
+    <url>https://github.com/cibseven/cibseven/issues</url>
+  </issueManagement>
+
+</project>

--- a/distro/wildfly/assembly/assembly.xml
+++ b/distro/wildfly/assembly/assembly.xml
@@ -70,6 +70,14 @@
       <directory>../modules/target/modules</directory>
       <outputDirectory>server/wildfly-${version.wildfly}/modules</outputDirectory>
     </fileSet>
+    <!-- ai-agent element-templates (extracted from the connector jar by the
+         dependency-plugin unpack in pom.xml): shipped to the standalone config
+         dir so the modeler discovers them via the file: path in
+         application-wildfly.yaml, independent of cross-module classpath*: scanning. -->
+    <fileSet>
+      <directory>target/ai-agent-templates/element-templates</directory>
+      <outputDirectory>server/wildfly-${version.wildfly}/standalone/configuration/element-templates</outputDirectory>
+    </fileSet>
   </fileSets>
   <files>
     <file>

--- a/distro/wildfly/assembly/pom.xml
+++ b/distro/wildfly/assembly/pom.xml
@@ -126,6 +126,36 @@
 
   <build>
     <plugins>
+      <!-- Extract the ai-agent connector's element-templates from the connector jar
+           so the WildFly-deployed modeler can find them via the file: path in
+           application-wildfly.yaml. classpath*: discovery is unreliable across JBoss
+           module boundaries, so we ship the JSONs onto the filesystem instead. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>extract-ai-agent-element-templates</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.cibseven.connect</groupId>
+                  <artifactId>cibseven-connect-ai-agent</artifactId>
+                  <version>${project.version}</version>
+                  <type>jar</type>
+                  <includes>element-templates/*.json</includes>
+                  <outputDirectory>${project.build.directory}/ai-agent-templates</outputDirectory>
+                  <overWrite>true</overWrite>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>

--- a/distro/wildfly/assembly/src/wildfly/standalone.conf
+++ b/distro/wildfly/assembly/src/wildfly/standalone.conf
@@ -50,7 +50,11 @@ fi
 # Specify options to pass to the Java VM.
 #
 if [ "x$JAVA_OPTS" = "x" ]; then
-   JAVA_OPTS="-Xms512m -Xmx768m -XX:MetaspaceSize=128M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true"
+   # MaxMetaspaceSize raised to 1024m so the optional ai-agent connector
+   # (LangChain4j/ONNX load a large number of classes) does not hit
+   # java.lang.OutOfMemoryError: Metaspace. It is a cap, not a reservation, so
+   # this is harmless for non-AI deployments. (CIB7-1445)
+   JAVA_OPTS="-Xms512m -Xmx768m -XX:MetaspaceSize=256m -XX:MaxMetaspaceSize=1024m -Djava.net.preferIPv4Stack=true"
    JAVA_OPTS="$JAVA_OPTS -Djboss.modules.system.pkgs=$JBOSS_MODULES_SYSTEM_PKGS -Djava.awt.headless=true"
 else
    echo "JAVA_OPTS already set in environment; overriding default settings with values: $JAVA_OPTS"

--- a/distro/wildfly/assembly/src/wildfly/standalone.conf.bat
+++ b/distro/wildfly/assembly/src/wildfly/standalone.conf.bat
@@ -46,7 +46,10 @@ rem # options that are always passed by run.bat.
 rem #
 
 rem # JVM memory allocation pool parameters - modify as appropriate.
-set "JAVA_OPTS=-Xms512m -Xmx768m -XX:MetaspaceSize=128M -XX:MaxMetaspaceSize=256m"
+rem # MaxMetaspaceSize raised to 1024m so the optional ai-agent connector
+rem # (LangChain4j/ONNX) does not hit OutOfMemoryError: Metaspace; it is a cap,
+rem # not a reservation, so this is harmless for non-AI deployments. (CIB7-1445)
+set "JAVA_OPTS=-Xms512m -Xmx768m -XX:MetaspaceSize=256m -XX:MaxMetaspaceSize=1024m"
 
 rem # Prefer IPv4
 set "JAVA_OPTS=%JAVA_OPTS% -Djava.net.preferIPv4Stack=true"

--- a/distro/wildfly/modules/pom.xml
+++ b/distro/wildfly/modules/pom.xml
@@ -77,6 +77,24 @@
       <artifactId>cibseven-connect-soap-http-client</artifactId>
     </dependency>
 
+    <!-- reactor-ordering only: ensures the ai-agent collector (which gathers the
+         connector + its LangChain4j/ONNX/pdfbox transitive jars into
+         target/dependency) builds before this module copies them into the fat
+         ai-agent JBoss module. The *:* exclusion keeps those jars off this
+         module's own classpath. -->
+    <dependency>
+      <groupId>org.cibseven.bpm.wildfly</groupId>
+      <artifactId>cibseven-wildfly-ai-agent</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
     <!-- script engine dependencies -->
     <dependency>
       <groupId>org.apache.groovy</groupId>
@@ -198,6 +216,20 @@
                   we are using the individual connect modules on Wildfly -->
                 <delete dir="target/modules/org/cibseven/connect/cibseven-connect-connectors-all" />
 
+                <!-- ai-agent fat module (CIB7-1445): copy the connector + all its
+                     LangChain4j/ONNX/pdfbox/pgvector transitive jars (gathered by the
+                     cibseven-wildfly-ai-agent collector) into a single module dir.
+                     Done after the org/cibseven/connect delete+copy above so it is
+                     not wiped. The matching module.xml (with a generated
+                     resource-root list) is added by the src/main/modules copy + the
+                     resource-root generation below. -->
+                <mkdir dir="target/modules/org/cibseven/connect/cibseven-connect-ai-agent/main" />
+                <copy todir="target/modules/org/cibseven/connect/cibseven-connect-ai-agent/main" flatten="true">
+                  <fileset dir="../ai-agent/target/dependency">
+                    <include name="*.jar" />
+                  </fileset>
+                </copy>
+
                 <delete dir="target/modules/org/cibseven/commons" />
                 <copy todir="target/modules" flatten="false">
                   <fileset refid="maven.project.dependencies" />
@@ -275,6 +307,22 @@
                 <copy todir="target/modules" flatten="false">
                   <fileset dir="src/main/modules" />
                 </copy>
+
+                <!-- ai-agent fat module: generate one <resource-root> per collected
+                     jar and inject it into the @resource-roots@ token of the shipped
+                     module.xml template (so the list never drifts as the connector's
+                     dependency set changes). -->
+                <pathconvert property="ai.agent.resource.roots" pathsep="&#10;">
+                  <fileset dir="target/modules/org/cibseven/connect/cibseven-connect-ai-agent/main">
+                    <include name="*.jar" />
+                  </fileset>
+                  <chainedmapper>
+                    <flattenmapper />
+                    <globmapper from="*" to="    &lt;resource-root path=&quot;*&quot;/&gt;" />
+                  </chainedmapper>
+                </pathconvert>
+                <replace file="target/modules/org/cibseven/connect/cibseven-connect-ai-agent/main/module.xml"
+                         token="@resource-roots@" value="${ai.agent.resource.roots}" />
 
                 <replace dir="target/modules" token="@project.version@" value="${project.version}">
                   <include name="**/module.xml" />

--- a/distro/wildfly/modules/src/main/modules/org/cibseven/bpm/cibseven-engine-plugin-connect/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/cibseven/bpm/cibseven-engine-plugin-connect/main/module.xml
@@ -12,6 +12,11 @@
     <module name="org.cibseven.connect.cibseven-connect-core" />
     <module name="org.cibseven.connect.cibseven-connect-http-client" services="import" />
     <module name="org.cibseven.connect.cibseven-connect-soap-http-client" services="import" />
+    <!-- ai-agent connector (CIB7-1445): optional=true so the engine still boots if
+         the ai-agent module dir is removed; services="import" registers it via the
+         cibseven-connect SPI. Disable by removing this import (docker
+         AI_AGENT_ENABLED=false) or deleting the module dir. -->
+    <module name="org.cibseven.connect.cibseven-connect-ai-agent" services="import" optional="true" />
 
   </dependencies>
 </module>

--- a/distro/wildfly/modules/src/main/modules/org/cibseven/connect/cibseven-connect-ai-agent/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/cibseven/connect/cibseven-connect-ai-agent/main/module.xml
@@ -1,0 +1,37 @@
+<module xmlns="urn:jboss:module:1.0" name="org.cibseven.connect.cibseven-connect-ai-agent">
+  <!-- Fat module: bundles the ai-agent connector and ALL its LangChain4j / ONNX /
+       pdfbox / pgvector transitive jars. The resource-root list below is GENERATED
+       at build time from the collected jars by the wildfly modules build, so it
+       never drifts as the connector's dependency set changes. -->
+  <resources>
+@resource-roots@
+  </resources>
+
+  <dependencies>
+    <module name="java.base" />
+    <module name="java.sql" />
+    <module name="java.naming" />
+    <module name="java.management" />
+    <!-- langchain4j-http-client-jdk uses java.net.http.HttpClient -->
+    <module name="java.net.http" />
+    <!-- pdfbox uses java.awt / javax.imageio -->
+    <module name="java.desktop" />
+    <!-- onnxruntime / jna may touch sun.misc.Unsafe -->
+    <module name="jdk.unsupported" />
+
+    <module name="org.slf4j" />
+
+    <module name="org.cibseven.commons.cibseven-commons-logging" />
+    <module name="org.cibseven.commons.cibseven-commons-utils" />
+
+    <!-- the connector SPI it implements -->
+    <module name="org.cibseven.connect.cibseven-connect-core" />
+    <!-- engine variable API (provided scope in the connector) -->
+    <module name="org.cibseven.bpm.cibseven-engine" />
+
+    <!-- JSON (provided scope in the connector) -->
+    <module name="com.fasterxml.jackson.core.jackson-databind" slot="@version.jackson@" />
+    <module name="com.fasterxml.jackson.core.jackson-core" slot="@version.jackson@" />
+    <module name="com.fasterxml.jackson.core.jackson-annotations" slot="@version.jackson@" />
+  </dependencies>
+</module>

--- a/distro/wildfly/pom.xml
+++ b/distro/wildfly/pom.xml
@@ -66,6 +66,7 @@
         <activeByDefault>true</activeByDefault>
       </activation>
       <modules>
+        <module>ai-agent</module>
         <module>assembly</module>
         <module>modules</module>
         <module>subsystem</module>


### PR DESCRIPTION
## What & why

Brings the `cibseven-connect-ai-agent` connector to the **WildFly** distribution (it previously shipped only in run + tomcat), as a single fat JBoss module — active by default, removable — matching the run/tomcat distros and CIB7-1299's non-invasive principle.

## How

- **`distro/wildfly/ai-agent/`** (new collector module): gathers the connector + its LangChain4j/ONNX/pdfbox/pgvector runtime jars into `target/dependency/`. Excludes `connect-core`, `slf4j-api`, and jackson (each provided by its own WildFly module).
- **`distro/wildfly/modules/pom.xml`**: copies those jars into a single module `org/cibseven/connect/cibseven-connect-ai-agent/main` and **generates the `<resource-root>` list at build time** (`pathconvert` → `@resource-roots@` token), so it never drifts as the dependency set changes.
- **`…/cibseven-connect-ai-agent/main/module.xml`** (new): authored dependency block (java.sql/naming/net.http/desktop, jdk.unsupported, slf4j, commons, connect-core, engine, jackson slot) + generated resource-roots.
- **`engine-plugin-connect/main/module.xml`**: imports the module `services="import" optional="true"` — active by default; `optional` so the engine still boots if the module dir is removed.

## Toggle (non-destructive)
- Standalone: delete the module dir.
- Docker (companion PR cibseven-docker): `AI_AGENT_ENABLED=false` removes the import line from `engine-plugin-connect`'s module.xml — jars untouched.

Element-template discovery is handled in the companion cibseven-webclient PR.

## Verified (build/structure only)
Clean build: **38 jars → 38 resource-roots**, `@resource-roots@`/`@version.jackson@` tokens replaced, jackson **not** bundled (kept as module deps), engine-plugin import present.

## ⚠️ Needs runtime validation (draft)
Can't boot WildFly in CI here. The **module dependency graph** (whether LangChain/ONNX/pdfbox need JDK modules beyond the generous set declared, native-lib loading) must be confirmed on a real WildFly boot. Opening as **draft** for that testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)