### PR TITLE
fix(deps): pin embedded Tomcat in run/run4 to patched 10.1.55/11.0.22 (CIB7-1457)

### DIFF
--- a/distro/run/pom.xml
+++ b/distro/run/pom.xml
@@ -18,6 +18,27 @@
   <dependencyManagement>
     <dependencies>
 
+      <!-- CVE fix: the embedded Tomcat is otherwise taken from the imported Spring Boot
+           BOM (10.1.54 for SB 3.5.x), which is affected by CVE-2026-41293, -43512, -43515,
+           -41284, -43513, -42498, -43514. Pin it to the patched 10.1.x line
+           (${version.tomcat10} from parent/pom.xml). Declared BEFORE the spring-boot-dependencies
+           import so this version wins over the BOM-managed one. -->
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>${version.tomcat10}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-el</artifactId>
+        <version>${version.tomcat10}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-websocket</artifactId>
+        <version>${version.tomcat10}</version>
+      </dependency>
+
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>

--- a/distro/run4/pom.xml
+++ b/distro/run4/pom.xml
@@ -18,6 +18,27 @@
   <dependencyManagement>
     <dependencies>
 
+      <!-- CVE fix: the embedded Tomcat is otherwise taken from the imported Spring Boot 4
+           BOM (11.0.21 for SB 4.0.x), which is affected by CVE-2026-41293, -43512, -43515,
+           -41284, -43513, -42498, -43514. Pin it to the patched 11.0.x line
+           (${version.tomcat} from parent/pom.xml). Declared BEFORE the spring-boot-dependencies
+           import so this version wins over the BOM-managed one. -->
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-el</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-websocket</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>


### PR DESCRIPTION
## Summary

The 2026-05-27 CVE bump (#340) updated the `version.tomcat*` properties and pgjdbc, which fixed the **standalone** Apache Tomcat distro (`distro/tomcat`), the QA runtimes, and the PostgreSQL driver. But the **embedded** Tomcat used by the Spring Boot distributions **`run` (SB3)** and **`run4` (SB4)** is pulled from the imported `spring-boot-dependencies` BOM — those properties never reach it — so it was still on the vulnerable versions:

| Distro | Spring Boot | Embedded Tomcat (before) | After |
|---|---|---|---|
| `run` (SB3) | 3.5.14 | **10.1.54** (vulnerable) | **10.1.55** |
| `run4` (SB4) | 4.0.6 | **11.0.21** (vulnerable) | **11.0.22** |

CVEs: CVE-2026-41293, CVE-2026-43512, CVE-2026-43515, CVE-2026-41284, CVE-2026-43513, CVE-2026-42498, CVE-2026-43514.

## Change

Pin `tomcat-embed-core` / `-el` / `-websocket` via `dependencyManagement` in `distro/run/pom.xml` (→ `${version.tomcat10}` = 10.1.55) and `distro/run4/pom.xml` (→ `${version.tomcat}` = 11.0.22). Both reuse the patched properties already defined in `parent/pom.xml`, and are declared **before** the `spring-boot-dependencies` import so the override wins over the BOM-managed version.

## Verification

`mvn -pl distro/run/core dependency:tree -Dincludes=org.apache.tomcat.embed` and the run4 equivalent:

```
run  → tomcat-embed-core/-el/-websocket : 10.1.55
run4 → tomcat-embed-core/-el/-websocket : 11.0.22
```

The standalone `distro/tomcat` (`org.apache.tomcat:tomcat` = 11.0.22) and pgjdbc (42.7.11) are unchanged.

## Out of scope
- swagger-ui: not bundled by the engine (only an OpenAPI JSON spec is generated).
- `webapps/frontend` dompurify 3.2.4 (< 3.4.0): same DOMPurify CVE family — tracked separately (Node/Vue frontend).
- `engine-rest/engine-rest` test-only `version.tomcat=7.0.50`: test scope, not shipped.

Ticket: CIB7-1457 (related to CIB7-1443 release QA and CIB7-1456 webclient CVE fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)