### PR TITLE
fix(distro): pin ai-agent collector copy-dependencies to target/dependency

### DIFF
--- a/distro/tomcat/ai-agent/pom.xml
+++ b/distro/tomcat/ai-agent/pom.xml
@@ -55,6 +55,11 @@
               <goal>copy-dependencies</goal>
             </goals>
             <configuration>
+              <!-- Pin the output to target/dependency, matching the path the tomcat
+                   assembly reads (../ai-agent/target/dependency/). Explicit so the
+                   third-party-bom tooling's generated-resources outputDirectory can
+                   never leak into this execution. -->
+              <outputDirectory>${project.build.directory}/dependency</outputDirectory>
               <includeScope>runtime</includeScope>
             </configuration>
           </execution>

--- a/distro/wildfly/ai-agent/pom.xml
+++ b/distro/wildfly/ai-agent/pom.xml
@@ -56,6 +56,12 @@
               <goal>copy-dependencies</goal>
             </goals>
             <configuration>
+              <!-- Pin the output to target/dependency. The third-party-bom tooling
+                   inherited from the parent configures maven-dependency-plugin with
+                   outputDirectory=target/generated-resources at plugin level, which
+                   would otherwise leak into this execution; the wildfly modules build
+                   reads the collected jars from ../ai-agent/target/dependency. -->
+              <outputDirectory>${project.build.directory}/dependency</outputDirectory>
               <includeScope>runtime</includeScope>
               <!-- slf4j + jackson are provided by their own WildFly modules (the
                    ai-agent module.xml depends on org.slf4j and the jackson slot);


### PR DESCRIPTION
## Problem

The license-book Jenkins build (and any full WildFly/Tomcat distro packaging) fails when assembling the new ai-agent module set:

```
[ERROR] Failed to execute goal ...maven-antrun-plugin:1.8:run (copy-dependencies)
        on project cibseven-wildfly-modules:
        An Ant BuildException has occured:
        .../distro/wildfly/ai-agent/target/dependency does not exist.
```

## Root cause

The `cibseven-wildfly-ai-agent` and `cibseven-tomcat-ai-agent` collector modules run `dependency:copy-dependencies` (execution `copy-ai-agent-dependencies`) **without an explicit `<outputDirectory>`**. With `skip-third-party-bom=false`, the inherited third-party-BOM tooling configures `maven-dependency-plugin` with `outputDirectory=${project.build.directory}/generated-resources` at plugin level, and that config leaks into this execution. So the jars land in `target/generated-resources` instead of `target/dependency`.

But the consumers read from `target/dependency`:
- WildFly: `distro/wildfly/modules/pom.xml` antrun `<fileset dir="../ai-agent/target/dependency">`
- Tomcat: `distro/tomcat/assembly/assembly.xml` `<directory>../ai-agent/target/dependency/</directory>`

→ the directory is never created → build failure.

## Fix

Set `<outputDirectory>${project.build.directory}/dependency</outputDirectory>` explicitly on the `copy-ai-agent-dependencies` execution in both collector poms, so the inherited `generated-resources` config can never override it.

## Verification

- `mvn -pl distro/wildfly/ai-agent package` → 38 jars in `target/dependency`, 0 in `generated-resources`.
- `mvn -pl distro/tomcat/ai-agent package` → 42 jars in `target/dependency`, 0 in `generated-resources`.

Refs CIB7-1445 (WildFly), CIB7-1444 (Tomcat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)