### PR TITLE
fix(webjar): mark dependencies as optional to prevent transitive inclusion

### DIFF
--- a/distro/run4/modules/webapps/pom.xml
+++ b/distro/run4/modules/webapps/pom.xml
@@ -25,14 +25,6 @@
     <dependency>
       <groupId>org.cibseven.bpm.springboot</groupId>
       <artifactId>cibseven-bpm-spring-boot-starter-webapp-4</artifactId>
-      <exclusions>
-        <!-- Exclude SB3 webclient-web pulled in transitively via cibseven-webapp-webjar;
-             the SB4 variant (cibseven-webclient-web-spring-boot-4) is already included -->
-        <exclusion>
-          <groupId>org.cibseven.webapp</groupId>
-          <artifactId>cibseven-webclient-web</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/distro/webjar/pom.xml
+++ b/distro/webjar/pom.xml
@@ -39,6 +39,7 @@
       <version>${project.parent.version}</version>
       <type>jar</type>
       <classifier>classes</classifier>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.cibseven.webapp</groupId>
@@ -46,6 +47,8 @@
       <version>${cibseven-webapp.version}</version>
       <type>jar</type>
       <classifier>classes</classifier>
+      <!-- optional prevents the dependency from being transitive to dependents -->
+      <optional>true</optional>
     </dependency>
   </dependencies>
 

--- a/spring-boot-4-starter/starter-webapp/pom.xml
+++ b/spring-boot-4-starter/starter-webapp/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>org.cibseven.bpm.webapp</groupId>
       <artifactId>cibseven-webapp-webjar</artifactId>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>

--- a/spring-boot-4-starter/starter-webapp/pom.xml
+++ b/spring-boot-4-starter/starter-webapp/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>org.cibseven.bpm.webapp</groupId>
       <artifactId>cibseven-webapp-webjar</artifactId>
-      </dependency>
+    </dependency>
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>


### PR DESCRIPTION
The webjar project is only intended to package static resources extracted from the web application WARs.

The JAR dependencies are not included in the final webjar package. They are added primarily to establish the build order and ensure the corresponding artifacts are available when the maven-dependency-plugin unpacks the WAR files during the build.

However, these dependencies also introduce transitive dependencies. Although those transitive dependencies are not packaged into the resulting webjar, they can still trigger dependency convergence issues during dependency resolution.

Since those dependencies are irrelevant to the contents of the generated webjar, they are marked as optional to prevent their transitive dependencies from propagating to downstream projects and causing unnecessary convergence issues.
(see CIB7-1486)
