### PR TITLE
fix(deps): pin embedded Tomcat in SB3/SB4 starters to 10.1.55/11.0.22…

### DIFF
--- a/spring-boot-4-starter/pom.xml
+++ b/spring-boot-4-starter/pom.xml
@@ -22,6 +22,28 @@
 
   <dependencyManagement>
     <dependencies>
+
+      <!-- CVE fix: the embedded Tomcat is otherwise taken from the imported Spring Boot 4
+           BOM (11.0.21 for SB 4.0.x), which is affected by CVE-2026-41293, -43512, -43515,
+           -41284, -43513, -42498, -43514. Pin it to the patched 11.0.x line
+           (${version.tomcat} from parent/pom.xml). Declared BEFORE the spring-boot-dependencies
+           import so this version wins over the BOM-managed one. -->
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-el</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-websocket</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+
       <dependency>
         <!-- Override HK2 from 4.0.0-M3 (bundled with Spring Boot) to 4.0.0 stable -->
         <groupId>org.glassfish.hk2</groupId>

--- a/spring-boot-starter/pom.xml
+++ b/spring-boot-starter/pom.xml
@@ -22,6 +22,28 @@
 
   <dependencyManagement>
     <dependencies>
+
+      <!-- CVE fix: the embedded Tomcat is otherwise taken from the imported Spring Boot
+           BOM (10.1.54 for SB 3.5.x), which is affected by CVE-2026-41293, -43512, -43515,
+           -41284, -43513, -42498, -43514. Pin it to the patched 10.1.x line
+           (${version.tomcat10} from parent/pom.xml). Declared BEFORE the spring-boot-dependencies
+           import so this version wins over the BOM-managed one. -->
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>${version.tomcat10}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-el</artifactId>
+        <version>${version.tomcat10}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-websocket</artifactId>
+        <version>${version.tomcat10}</version>
+      </dependency>
+
       <dependency>
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
… (CIB7-1457)

Commit 5c7e909 (#351) / #352 pinned the embedded Tomcat for the Spring Boot distros (distro/run -> 10.1.55, distro/run4 -> 11.0.22) but left the two starter entry points still resolving the vulnerable versions from the imported spring-boot-dependencies BOM:
  spring-boot-starter   (SB 3.5.x) -> tomcat-embed 10.1.54
  spring-boot-4-starter (SB 4.0.x) -> tomcat-embed 11.0.21

These roots expose cibseven-bpm-spring-boot-starter-rest, which transitively pulls tomcat-embed via spring-boot-starter-jersey/-tomcat (CVE-2026-41293, -43512, -43515, -41284, -43513, -42498, -43514).

Pin tomcat-embed-core/-el/-websocket via dependencyManagement in the two starter-root poms (-> ${version.tomcat10} = 10.1.55 / ${version.tomcat} = 11.0.22), declared before the spring-boot-dependencies import so the override
wins. Verified via dependency:tree: starter-rest -> 10.1.55, starter-rest-4 ->
11.0.22.