### PR TITLE
chore: add SQL upgrade scripts for engine version 2.3.0 and update previous version references in POM files

### DIFF
--- a/engine/src/main/resources/org/cibseven/bpm/engine/db/upgrade/db2_engine_2.2_to_2.3.sql
+++ b/engine/src/main/resources/org/cibseven/bpm/engine/db/upgrade/db2_engine_2.2_to_2.3.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright CIB software GmbH and/or licensed to CIB software GmbH
+-- under one or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information regarding copyright
+-- ownership. CIB software licenses this file to you under the Apache License,
+-- Version 2.0; you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+insert into ACT_GE_SCHEMA_LOG
+values ('1600', CURRENT_TIMESTAMP, '2.3.0');

--- a/engine/src/main/resources/org/cibseven/bpm/engine/db/upgrade/h2_engine_2.2_to_2.3.sql
+++ b/engine/src/main/resources/org/cibseven/bpm/engine/db/upgrade/h2_engine_2.2_to_2.3.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright CIB software GmbH and/or licensed to CIB software GmbH
+-- under one or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information regarding copyright
+-- ownership. CIB software licenses this file to you under the Apache License,
+-- Version 2.0; you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+insert into ACT_GE_SCHEMA_LOG
+values ('1600', CURRENT_TIMESTAMP, '2.3.0');

--- a/engine/src/main/resources/org/cibseven/bpm/engine/db/upgrade/mariadb_engine_2.2_to_2.3.sql
+++ b/engine/src/main/resources/org/cibseven/bpm/engine/db/upgrade/mariadb_engine_2.2_to_2.3.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright CIB software GmbH and/or licensed to CIB software GmbH
+-- under one or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information regarding copyright
+-- ownership. CIB software licenses this file to you under the Apache License,
+-- Version 2.0; you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+insert into ACT_GE_SCHEMA_LOG
+values ('1600', CURRENT_TIMESTAMP, '2.3.0');

--- a/engine/src/main/resources/org/cibseven/bpm/engine/db/upgrade/mssql_engine_2.2_to_2.3.sql
+++ b/engine/src/main/resources/org/cibseven/bpm/engine/db/upgrade/mssql_engine_2.2_to_2.3.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright CIB software GmbH and/or licensed to CIB software GmbH
+-- under one or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information regarding copyright
+-- ownership. CIB software licenses this file to you under the Apache License,
+-- Version 2.0; you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+insert into ACT_GE_SCHEMA_LOG
+values ('1600', CURRENT_TIMESTAMP, '2.3.0');

--- a/engine/src/main/resources/org/cibseven/bpm/engine/db/upgrade/mysql_engine_2.2_to_2.3.sql
+++ b/engine/src/main/resources/org/cibseven/bpm/engine/db/upgrade/mysql_engine_2.2_to_2.3.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright CIB software GmbH and/or licensed to CIB software GmbH
+-- under one or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information regarding copyright
+-- ownership. CIB software licenses this file to you under the Apache License,
+-- Version 2.0; you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+insert into ACT_GE_SCHEMA_LOG
+values ('1600', CURRENT_TIMESTAMP, '2.3.0');

--- a/engine/src/main/resources/org/cibseven/bpm/engine/db/upgrade/oracle_engine_2.2_to_2.3.sql
+++ b/engine/src/main/resources/org/cibseven/bpm/engine/db/upgrade/oracle_engine_2.2_to_2.3.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright CIB software GmbH and/or licensed to CIB software GmbH
+-- under one or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information regarding copyright
+-- ownership. CIB software licenses this file to you under the Apache License,
+-- Version 2.0; you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+insert into ACT_GE_SCHEMA_LOG
+values ('1600', CURRENT_TIMESTAMP, '2.3.0');

--- a/engine/src/main/resources/org/cibseven/bpm/engine/db/upgrade/postgres_engine_2.2_to_2.3.sql
+++ b/engine/src/main/resources/org/cibseven/bpm/engine/db/upgrade/postgres_engine_2.2_to_2.3.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright CIB software GmbH and/or licensed to CIB software GmbH
+-- under one or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information regarding copyright
+-- ownership. CIB software licenses this file to you under the Apache License,
+-- Version 2.0; you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+insert into ACT_GE_SCHEMA_LOG
+values ('1600', CURRENT_TIMESTAMP, '2.3.0');

--- a/qa/test-db-rolling-update/create-new-engine/pom.xml
+++ b/qa/test-db-rolling-update/create-new-engine/pom.xml
@@ -13,7 +13,6 @@
 
   <properties>
     <cibseven.version.current>${project.version}</cibseven.version.current>
-    <cibseven.version.previous>2.1.0</cibseven.version.previous>
   </properties>
 
   <dependencies>

--- a/qa/test-db-rolling-update/create-old-engine/pom.xml
+++ b/qa/test-db-rolling-update/create-old-engine/pom.xml
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>org.cibseven.bpm</groupId>
         <artifactId>cibseven-bom</artifactId>
-        <version>2.0.0</version>
+        <version>${cibseven.version.previous}</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/qa/test-db-rolling-update/pom.xml
+++ b/qa/test-db-rolling-update/pom.xml
@@ -13,6 +13,11 @@
     <version>2.3.0-SNAPSHOT</version>
   </parent>
 
+  <!-- centralized previous version for old-engine BOMs; update only on release or override via -Dcibseven.version.previous -->
+  <properties>
+    <cibseven.version.previous>2.2.0</cibseven.version.previous>
+  </properties>
+
   <modules>
     <module>rolling-update-util</module>
     <module>create-old-engine</module>

--- a/qa/test-db-rolling-update/rolling-update-util/pom.xml
+++ b/qa/test-db-rolling-update/rolling-update-util/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
         <groupId>org.cibseven.bpm</groupId>
         <artifactId>cibseven-bom</artifactId>
-        <version>2.0.0</version>
+        <version>${cibseven.version.previous}</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/qa/test-db-rolling-update/test-old-engine/pom.xml
+++ b/qa/test-db-rolling-update/test-old-engine/pom.xml
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>org.cibseven.bpm</groupId>
         <artifactId>cibseven-bom</artifactId>
-        <version>2.0.0</version>
+        <version>${cibseven.version.previous}</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
* Added SQL upgrade scripts from 2.2 to 2.3
* Rolling updates are direct upgrades, not successive hops -> centralized property for old engine BOM and create-new-engine project plugins.