### PR TITLE
chore(LdapPlugin): remove LDAP cache property comments from serven configs

### DIFF
--- a/distro/tomcat/assembly/src/conf/bpm-platform.xml
+++ b/distro/tomcat/assembly/src/conf/bpm-platform.xml
@@ -78,14 +78,12 @@
           <property name="groupMemberAttribute">member</property>
           <property name="sortControlSupported">false</property>
 
-          <!-- Optional in-memory caching of LDAP lookups (disabled by default). -->
-          <!-- maxWeight bounds the number of cached users/groups, not the number of queries. -->
           <property name="cacheEnabled">false</property>
           <property name="cacheUserQueriesTtlSeconds">30</property>
           <property name="cacheUserQueriesMaxWeight">10000</property>
           <property name="cacheGroupTtlSeconds">120</property>
           <property name="cacheGroupMaxWeight">5000</property>
-          <!-- Periodic INFO logging of cache hit/miss statistics; debug aid only. -->
+          
           <property name="cacheStatsLogEnabled">false</property>
           <property name="cacheStatsLogInterval">1000</property>
 

--- a/distro/wildfly/assembly/src/wildfly/standalone-full.xml
+++ b/distro/wildfly/assembly/src/wildfly/standalone-full.xml
@@ -619,14 +619,12 @@
                                     <property name="groupMemberAttribute">member</property>
                                     <property name="sortControlSupported">false</property>
 
-                                    <!-- Optional in-memory caching of LDAP lookups (disabled by default). -->
-                                    <!-- maxWeight bounds the number of cached users/groups, not the number of queries. -->
                                     <property name="cacheEnabled">false</property>
                                     <property name="cacheUserQueriesTtlSeconds">30</property>
                                     <property name="cacheUserQueriesMaxWeight">10000</property>
                                     <property name="cacheGroupTtlSeconds">120</property>
                                     <property name="cacheGroupMaxWeight">5000</property>
-                                    <!-- Periodic INFO logging of cache hit/miss statistics; debug aid only. -->
+                                    
                                     <property name="cacheStatsLogEnabled">false</property>
                                     <property name="cacheStatsLogInterval">1000</property>
                                 </properties>

--- a/distro/wildfly/assembly/src/wildfly/standalone.xml
+++ b/distro/wildfly/assembly/src/wildfly/standalone.xml
@@ -577,14 +577,12 @@
                                     <property name="groupMemberAttribute">member</property>
                                     <property name="sortControlSupported">false</property>
 
-                                    <!-- Optional in-memory caching of LDAP lookups (disabled by default). -->
-                                    <!-- maxWeight bounds the number of cached users/groups, not the number of queries. -->
                                     <property name="cacheEnabled">false</property>
                                     <property name="cacheUserQueriesTtlSeconds">30</property>
                                     <property name="cacheUserQueriesMaxWeight">10000</property>
                                     <property name="cacheGroupTtlSeconds">120</property>
                                     <property name="cacheGroupMaxWeight">5000</property>
-                                    <!-- Periodic INFO logging of cache hit/miss statistics; debug aid only. -->
+                                    
                                     <property name="cacheStatsLogEnabled">false</property>
                                     <property name="cacheStatsLogInterval">1000</property>
                                 </properties>

--- a/distro/wildfly28/assembly/src/wildfly/standalone-full.xml
+++ b/distro/wildfly28/assembly/src/wildfly/standalone-full.xml
@@ -618,14 +618,12 @@
                                     <property name="groupMemberAttribute">member</property>
                                     <property name="sortControlSupported">false</property>
 
-                                    <!-- Optional in-memory caching of LDAP lookups (disabled by default). -->
-                                    <!-- maxWeight bounds the number of cached users/groups, not the number of queries. -->
                                     <property name="cacheEnabled">false</property>
                                     <property name="cacheUserQueriesTtlSeconds">30</property>
                                     <property name="cacheUserQueriesMaxWeight">10000</property>
                                     <property name="cacheGroupTtlSeconds">120</property>
                                     <property name="cacheGroupMaxWeight">5000</property>
-                                    <!-- Periodic INFO logging of cache hit/miss statistics; debug aid only. -->
+                                    
                                     <property name="cacheStatsLogEnabled">false</property>
                                     <property name="cacheStatsLogInterval">1000</property>
                                 </properties>

--- a/distro/wildfly28/assembly/src/wildfly/standalone.xml
+++ b/distro/wildfly28/assembly/src/wildfly/standalone.xml
@@ -576,14 +576,12 @@
 	                              <property name="groupMemberAttribute">member</property>
 	                              <property name="sortControlSupported">false</property>
 
-	                              <!-- Optional in-memory caching of LDAP lookups (disabled by default). -->
-	                              <!-- maxWeight bounds the number of cached users/groups, not the number of queries. -->
 	                              <property name="cacheEnabled">false</property>
 	                              <property name="cacheUserQueriesTtlSeconds">30</property>
 	                              <property name="cacheUserQueriesMaxWeight">10000</property>
 	                              <property name="cacheGroupTtlSeconds">120</property>
 	                              <property name="cacheGroupMaxWeight">5000</property>
-	                              <!-- Periodic INFO logging of cache hit/miss statistics; debug aid only. -->
+                                  
 	                              <property name="cacheStatsLogEnabled">false</property>
 	                              <property name="cacheStatsLogInterval">1000</property>
 	                          </properties>

--- a/qa/tomcat-runtime/src/main/conf/bpm-platform.xml
+++ b/qa/tomcat-runtime/src/main/conf/bpm-platform.xml
@@ -68,14 +68,12 @@
           <property name="groupMemberAttribute">member</property>
           <property name="sortControlSupported">false</property>
 
-          <!-- Optional in-memory caching of LDAP lookups (disabled by default). -->
-          <!-- maxWeight bounds the number of cached users/groups, not the number of queries. -->
           <property name="cacheEnabled">false</property>
           <property name="cacheUserQueriesTtlSeconds">30</property>
           <property name="cacheUserQueriesMaxWeight">10000</property>
           <property name="cacheGroupTtlSeconds">120</property>
           <property name="cacheGroupMaxWeight">5000</property>
-          <!-- Periodic INFO logging of cache hit/miss statistics; debug aid only. -->
+          
           <property name="cacheStatsLogEnabled">false</property>
           <property name="cacheStatsLogInterval">1000</property>
 

--- a/qa/tomcat10-runtime/src/main/conf/bpm-platform.xml
+++ b/qa/tomcat10-runtime/src/main/conf/bpm-platform.xml
@@ -68,14 +68,12 @@
           <property name="groupMemberAttribute">member</property>
           <property name="sortControlSupported">false</property>
 
-          <!-- Optional in-memory caching of LDAP lookups (disabled by default). -->
-          <!-- maxWeight bounds the number of cached users/groups, not the number of queries. -->
           <property name="cacheEnabled">false</property>
           <property name="cacheUserQueriesTtlSeconds">30</property>
           <property name="cacheUserQueriesMaxWeight">10000</property>
           <property name="cacheGroupTtlSeconds">120</property>
           <property name="cacheGroupMaxWeight">5000</property>
-          <!-- Periodic INFO logging of cache hit/miss statistics; debug aid only. -->
+          
           <property name="cacheStatsLogEnabled">false</property>
           <property name="cacheStatsLogInterval">1000</property>
 

--- a/qa/tomcat9-runtime/src/main/conf/bpm-platform.xml
+++ b/qa/tomcat9-runtime/src/main/conf/bpm-platform.xml
@@ -67,14 +67,12 @@
           <property name="groupMemberAttribute">member</property>
           <property name="sortControlSupported">false</property>
 
-          <!-- Optional in-memory caching of LDAP lookups (disabled by default). -->
-          <!-- maxWeight bounds the number of cached users/groups, not the number of queries. -->
           <property name="cacheEnabled">false</property>
           <property name="cacheUserQueriesTtlSeconds">30</property>
           <property name="cacheUserQueriesMaxWeight">10000</property>
           <property name="cacheGroupTtlSeconds">120</property>
           <property name="cacheGroupMaxWeight">5000</property>
-          <!-- Periodic INFO logging of cache hit/miss statistics; debug aid only. -->
+          
           <property name="cacheStatsLogEnabled">false</property>
           <property name="cacheStatsLogInterval">1000</property>
 


### PR DESCRIPTION
Drop the explanatory comments around the LDAP cache properties in the Tomcat and WildFly distro/qa configuration templates, keeping only the property declarations themselves.