### PR TITLE
fix(test): allow schrinkwrapresolver to get local repo from MAVEN_OPTS

### DIFF
--- a/Jenkinsfile.cib
+++ b/Jenkinsfile.cib
@@ -100,7 +100,7 @@ pipeline {
     environment {
         MAVEN_LOCAL_REPO = getLocalJobRepo(env.JOB_NAME, params.USE_PRIVATE_REPO)
         // set bigger timeout to get rid of the maven issue with file locks: https://github.com/apache/maven/issues/9049
-        MAVEN_LOCAL_REPO_OPTS = "-Dmaven.repo.local=${env.MAVEN_LOCAL_REPO} -Daether.connector.basic.threads=4 -Daether.metadataResolver.threads=4 -Daether.syncContext.named.time=120"
+        MAVEN_LOCAL_REPO_OPTS = "-Dmaven.repo.local=${env.MAVEN_LOCAL_REPO} -Daether.syncContext.named.time=120"
         // set maven options only if params.USE_PRIVATE_REPO is true, otherwise use shared repo as usual
         MAVEN_OPTS = "${params.USE_PRIVATE_REPO == true ? env.MAVEN_LOCAL_REPO_OPTS : ""}"
     }

--- a/engine-rest/engine-rest/src/test/java/org/cibseven/bpm/engine/rest/util/container/TomcatServerBootstrap.java
+++ b/engine-rest/engine-rest/src/test/java/org/cibseven/bpm/engine/rest/util/container/TomcatServerBootstrap.java
@@ -37,6 +37,28 @@ import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenDependencies;
 
 public abstract class TomcatServerBootstrap extends AbstractServerBootstrap {
 
+  /**
+   * On CI (Jenkins), the local Maven repository is redirected via -Dmaven.repo.local in MAVEN_OPTS.
+   * Surefire forks a new JVM that inherits MAVEN_OPTS as an environment variable but does NOT
+   * parse it into JVM system properties. ShrinkWrap's resolver checks the system property,
+   * so it falls back to ~/.m2/repository and can't find artifacts from the custom local repo.
+   */
+  static {
+    String mavenOpts = System.getenv("MAVEN_OPTS");
+    if (mavenOpts != null) {
+      String prefix = "-Dmaven.repo.local=";
+      int idx = mavenOpts.indexOf(prefix);
+      if (idx >= 0) {
+        String rest = mavenOpts.substring(idx + prefix.length());
+        int end = rest.indexOf(' ');
+        String repoPath = (end >= 0) ? rest.substring(0, end) : rest;
+        if (!repoPath.isEmpty()) {
+          System.setProperty("maven.repo.local", repoPath);
+        }
+      }
+    }
+  }
+
   private Tomcat tomcat;
   private String workingDir;
   private String webXmlPath;

--- a/qa/integration-tests-engine/src/test/java/org/cibseven/bpm/integrationtest/deployment/war/TestWarDeploymentWithProcessEnginePlugin.java
+++ b/qa/integration-tests-engine/src/test/java/org/cibseven/bpm/integrationtest/deployment/war/TestWarDeploymentWithProcessEnginePlugin.java
@@ -42,6 +42,28 @@ import static org.junit.Assert.assertEquals;
 @RunWith(Arquillian.class)
 public class TestWarDeploymentWithProcessEnginePlugin extends AbstractFoxPlatformIntegrationTest {
 
+  /**
+   * On CI (Jenkins), the local Maven repository is redirected via -Dmaven.repo.local in MAVEN_OPTS.
+   * Surefire forks a new JVM that inherits MAVEN_OPTS as an environment variable but does NOT
+   * parse it into JVM system properties. ShrinkWrap's resolver checks the system property,
+   * so it falls back to ~/.m2/repository and can't find artifacts from the custom local repo.
+   */
+  static {
+    String mavenOpts = System.getenv("MAVEN_OPTS");
+    if (mavenOpts != null) {
+      String prefix = "-Dmaven.repo.local=";
+      int idx = mavenOpts.indexOf(prefix);
+      if (idx >= 0) {
+        String rest = mavenOpts.substring(idx + prefix.length());
+        int end = rest.indexOf(' ');
+        String repoPath = (end >= 0) ? rest.substring(0, end) : rest;
+        if (!repoPath.isEmpty()) {
+          System.setProperty("maven.repo.local", repoPath);
+        }
+      }
+    }
+  }
+
   @Deployment
   public static WebArchive processArchive() {
     return initWebArchiveDeployment("test.war", "singleEngineWithProcessEnginePlugin.xml")

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/cibseven/bpm/rest/EmbeddedEngineRest_WILDFLY.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/cibseven/bpm/rest/EmbeddedEngineRest_WILDFLY.java
@@ -37,6 +37,28 @@ import java.io.IOException;
 @RunWith(Arquillian.class)
 public class EmbeddedEngineRest_WILDFLY {
 
+  /**
+   * On CI (Jenkins), the local Maven repository is redirected via -Dmaven.repo.local in MAVEN_OPTS.
+   * Surefire forks a new JVM that inherits MAVEN_OPTS as an environment variable but does NOT
+   * parse it into JVM system properties. ShrinkWrap's resolver checks the system property,
+   * so it falls back to ~/.m2/repository and can't find artifacts from the custom local repo.
+   */
+  static {
+    String mavenOpts = System.getenv("MAVEN_OPTS");
+    if (mavenOpts != null) {
+      String prefix = "-Dmaven.repo.local=";
+      int idx = mavenOpts.indexOf(prefix);
+      if (idx >= 0) {
+        String rest = mavenOpts.substring(idx + prefix.length());
+        int end = rest.indexOf(' ');
+        String repoPath = (end >= 0) ? rest.substring(0, end) : rest;
+        if (!repoPath.isEmpty()) {
+          System.setProperty("maven.repo.local", repoPath);
+        }
+      }
+    }
+  }
+
   private static final String EMBEDDED_ENGINE_REST = "embedded-engine-rest";
 
   @ArquillianResource


### PR DESCRIPTION
* when local repo is specified in MAVEN_OPTS then use it instead of the default one
* remove aether threads options (use defaults)