### PR TITLE
CIB7-1613: add orderByVariableId() and Query#stream() for stable pagination

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/variable-instance-query-params.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/variable-instance-query-params.ftl
@@ -1,6 +1,7 @@
 <#-- Generated From File: camunda-docs-manual/public/reference/rest/variable-instance/get-query/index.html -->
 
 <#assign sortByValues = [
+  '"variableId"',
   '"variableName"',
   '"variableType"',
   '"activityInstanceId"',

--- a/engine-rest/engine-rest/src/main/java/org/cibseven/bpm/engine/rest/dto/runtime/VariableInstanceQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/cibseven/bpm/engine/rest/dto/runtime/VariableInstanceQueryDto.java
@@ -41,6 +41,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class VariableInstanceQueryDto extends AbstractQueryDto<VariableInstanceQuery> {
 
+  private static final String SORT_BY_VARIABLE_ID_VALUE = "variableId";
   private static final String SORT_BY_VARIABLE_NAME_VALUE = "variableName";
   private static final String SORT_BY_VARIABLE_TYPE_VALUE = "variableType";
   private static final String SORT_BY_ACTIVITY_INSTANCE_ID_VALUE = "activityInstanceId";
@@ -49,6 +50,7 @@ public class VariableInstanceQueryDto extends AbstractQueryDto<VariableInstanceQ
   private static final List<String> VALID_SORT_BY_VALUES;
   static {
     VALID_SORT_BY_VALUES = new ArrayList<String>();
+    VALID_SORT_BY_VALUES.add(SORT_BY_VARIABLE_ID_VALUE);
     VALID_SORT_BY_VALUES.add(SORT_BY_VARIABLE_NAME_VALUE);
     VALID_SORT_BY_VALUES.add(SORT_BY_VARIABLE_TYPE_VALUE);
     VALID_SORT_BY_VALUES.add(SORT_BY_ACTIVITY_INSTANCE_ID_VALUE);
@@ -238,7 +240,9 @@ public class VariableInstanceQueryDto extends AbstractQueryDto<VariableInstanceQ
 
   @Override
   protected void applySortBy(VariableInstanceQuery query, String sortBy, Map<String, Object> parameters, ProcessEngine engine) {
-    if (sortBy.equals(SORT_BY_VARIABLE_NAME_VALUE)) {
+    if (sortBy.equals(SORT_BY_VARIABLE_ID_VALUE)) {
+      query.orderByVariableId();
+    } else if (sortBy.equals(SORT_BY_VARIABLE_NAME_VALUE)) {
       query.orderByVariableName();
     } else if (sortBy.equals(SORT_BY_VARIABLE_TYPE_VALUE)) {
       query.orderByVariableType();

--- a/engine-rest/engine-rest/src/test/java/org/cibseven/bpm/engine/rest/VariableInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/cibseven/bpm/engine/rest/VariableInstanceRestServiceQueryTest.java
@@ -200,6 +200,16 @@ public class VariableInstanceRestServiceQueryTest extends AbstractRestServiceTes
   @Test
   public void testSortingParameters() {
     InOrder inOrder = Mockito.inOrder(mockedQuery);
+    executeAndVerifySorting("variableId", "asc", Status.OK);
+    inOrder.verify(mockedQuery).orderByVariableId();
+    inOrder.verify(mockedQuery).asc();
+
+    inOrder = Mockito.inOrder(mockedQuery);
+    executeAndVerifySorting("variableId", "desc", Status.OK);
+    inOrder.verify(mockedQuery).orderByVariableId();
+    inOrder.verify(mockedQuery).desc();
+
+    inOrder = Mockito.inOrder(mockedQuery);
     executeAndVerifySorting("variableName", "asc", Status.OK);
     inOrder.verify(mockedQuery).orderByVariableName();
     inOrder.verify(mockedQuery).asc();

--- a/engine/src/main/java/org/cibseven/bpm/engine/history/HistoricVariableInstanceQuery.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/history/HistoricVariableInstanceQuery.java
@@ -138,6 +138,10 @@ public interface HistoricVariableInstanceQuery extends Query<HistoricVariableIns
    */
   HistoricVariableInstanceQuery createdAfter(Date date);
 
+  /**
+   * Streams all matching results using stable keyset (seek) pagination ordered by variable id,
+   * so the stream contains no duplicates and skips no entries under concurrent inserts/deletes.
+   */
   Stream<HistoricVariableInstance> streamStable();
 
 }

--- a/engine/src/main/java/org/cibseven/bpm/engine/history/HistoricVariableInstanceQuery.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/history/HistoricVariableInstanceQuery.java
@@ -17,6 +17,8 @@
 package org.cibseven.bpm.engine.history;
 
 import java.util.Date;
+import java.util.stream.Stream;
+
 import org.cibseven.bpm.engine.query.Query;
 
 
@@ -135,5 +137,7 @@ public interface HistoricVariableInstanceQuery extends Query<HistoricVariableIns
    * Only select historic process variables that were created after the given date.
    */
   HistoricVariableInstanceQuery createdAfter(Date date);
+
+  Stream<HistoricVariableInstance> streamStable();
 
 }

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/AbstractQuery.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/AbstractQuery.java
@@ -158,6 +158,21 @@ public abstract class AbstractQuery<T extends Query<?,?>, U> extends ListQueryPa
     return (List<U>) executeResult(resultType);
   }
 
+/**
+* Streams results using keyset (seek) pagination: each page is fetched by
+* "id greater than the last streamed id" rather than by numeric offset.
+*
+* <p>Unlike offset pagination, concurrent inserts/deletes do not shift the
+* cursor, so no row is returned twice and no row present when iteration
+* passed its id is skipped. Requires {@code id} to be unique, immutable, and
+* consistent with the applied ascending ordering. Rows inserted ahead of the
+* cursor may still appear; rows inserted behind it will not.
+*
+* @param idExtractor         reads the unique, orderable id from a result row
+* @param cursorSetter        applies the "id greater than" cursor; called with
+*                            {@code null} to reset prior state
+* @param applyUniqueOrdering clears current ordering and orders ascending by id
+*/
   protected Stream<U> streamByKeyset(Function<U, String> idExtractor, Consumer<String> cursorSetter,
       Runnable applyUniqueOrdering) {
     return streamByKeyset(100, idExtractor, cursorSetter, applyUniqueOrdering);

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/AbstractQuery.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/AbstractQuery.java
@@ -158,39 +158,6 @@ public abstract class AbstractQuery<T extends Query<?,?>, U> extends ListQueryPa
     return (List<U>) executeResult(resultType);
   }
 
-  /**
-   * Shared building block for query types that want a {@link Query#stream()} backed by keyset
-   * (seek) pagination instead of the {@link Query#stream() default} OFFSET-based one.
-   *
-   * <p>OFFSET-based pagination (as used by {@link #listPage(int, int)} and the default
-   * {@link Query#stream()}) fetches each subsequent page by numeric position ("skip N rows").
-   * If rows are inserted or deleted anywhere in the underlying table between two page fetches,
-   * every row's position shifts, which can cause rows to be returned twice or not at all -
-   * regardless of which column the query is ordered by, since positions shift independently of
-   * sort values.
-   *
-   * <p>Keyset pagination avoids this: each subsequent page is fetched by filtering on
-   * "id greater than the last id already streamed" instead of a numeric offset. As long as the
-   * id is unique and immutable, this filter is unaffected by concurrent inserts or deletes
-   * elsewhere in the table - no row can be returned twice, and no row already present when the
-   * stream started iterating past it can be skipped. On top of correctness, this also performs
-   * better than deep OFFSET pagination, since it can use an index seek on the (typically
-   * primary-key-backed) id column instead of the database having to skip over positions.
-   *
-   * <p>This requires the stream to fully own the ordering: {@code applyUniqueOrdering} must
-   * clear any previously configured ordering and replace it with an ascending order on the same
-   * property {@code idExtractor}/{@code cursorSetter} operate on - keyset pagination is only
-   * correct for a single, unique sort key.
-   *
-   * @param idExtractor reads the unique, orderable id from a result row
-   * @param cursorSetter applies the "id greater than" cursor to this query (backed by a
-   *                     query-specific field wired into a "greater than" SQL filter); called
-   *                     with {@code null} once at the start to reset any state left over from a
-   *                     previous invocation
-   * @param applyUniqueOrdering clears the current ordering and orders the query ascending by the
-   *                            same property used by {@code idExtractor}/{@code cursorSetter}
-   * @return a lazily evaluated stream of results
-   */
   protected Stream<U> streamByKeyset(Function<U, String> idExtractor, Consumer<String> cursorSetter,
       Runnable applyUniqueOrdering) {
     return streamByKeyset(100, idExtractor, cursorSetter, applyUniqueOrdering);

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/AbstractQuery.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/AbstractQuery.java
@@ -25,9 +25,17 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import org.cibseven.bpm.engine.ProcessEngineException;
 import org.cibseven.bpm.engine.exception.NotValidException;
@@ -148,6 +156,89 @@ public abstract class AbstractQuery<T extends Query<?,?>, U> extends ListQueryPa
     this.maxResults = maxResults;
     this.resultType = ResultType.LIST_PAGE;
     return (List<U>) executeResult(resultType);
+  }
+
+  /**
+   * Shared building block for query types that want a {@link Query#stream()} backed by keyset
+   * (seek) pagination instead of the {@link Query#stream() default} OFFSET-based one.
+   *
+   * <p>OFFSET-based pagination (as used by {@link #listPage(int, int)} and the default
+   * {@link Query#stream()}) fetches each subsequent page by numeric position ("skip N rows").
+   * If rows are inserted or deleted anywhere in the underlying table between two page fetches,
+   * every row's position shifts, which can cause rows to be returned twice or not at all -
+   * regardless of which column the query is ordered by, since positions shift independently of
+   * sort values.
+   *
+   * <p>Keyset pagination avoids this: each subsequent page is fetched by filtering on
+   * "id greater than the last id already streamed" instead of a numeric offset. As long as the
+   * id is unique and immutable, this filter is unaffected by concurrent inserts or deletes
+   * elsewhere in the table - no row can be returned twice, and no row already present when the
+   * stream started iterating past it can be skipped. On top of correctness, this also performs
+   * better than deep OFFSET pagination, since it can use an index seek on the (typically
+   * primary-key-backed) id column instead of the database having to skip over positions.
+   *
+   * <p>This requires the stream to fully own the ordering: {@code applyUniqueOrdering} must
+   * clear any previously configured ordering and replace it with an ascending order on the same
+   * property {@code idExtractor}/{@code cursorSetter} operate on - keyset pagination is only
+   * correct for a single, unique sort key.
+   *
+   * @param idExtractor reads the unique, orderable id from a result row
+   * @param cursorSetter applies the "id greater than" cursor to this query (backed by a
+   *                     query-specific field wired into a "greater than" SQL filter); called
+   *                     with {@code null} once at the start to reset any state left over from a
+   *                     previous invocation
+   * @param applyUniqueOrdering clears the current ordering and orders the query ascending by the
+   *                            same property used by {@code idExtractor}/{@code cursorSetter}
+   * @return a lazily evaluated stream of results
+   */
+  protected Stream<U> streamByKeyset(Function<U, String> idExtractor, Consumer<String> cursorSetter,
+      Runnable applyUniqueOrdering) {
+    return streamByKeyset(100, idExtractor, cursorSetter, applyUniqueOrdering);
+  }
+
+  protected Stream<U> streamByKeyset(int pageSize, Function<U, String> idExtractor, Consumer<String> cursorSetter,
+      Runnable applyUniqueOrdering) {
+    cursorSetter.accept(null);
+    setOrderingProperties(new ArrayList<QueryOrderingProperty>());
+    applyUniqueOrdering.run();
+
+    Iterator<U> iterator = new Iterator<U>() {
+
+      protected List<U> page = null;
+      protected int indexInPage = 0;
+      protected boolean lastPageReached = false;
+
+      @Override
+      public boolean hasNext() {
+        if (page != null && indexInPage < page.size()) {
+          return true;
+        }
+        if (lastPageReached) {
+          return false;
+        }
+        page = listPage(0, pageSize);
+        indexInPage = 0;
+        if (!page.isEmpty()) {
+          cursorSetter.accept(idExtractor.apply(page.get(page.size() - 1)));
+        }
+        if (page.size() < pageSize) {
+          lastPageReached = true;
+        }
+        return indexInPage < page.size();
+      }
+
+      @Override
+      public U next() {
+        if (!hasNext()) {
+          throw new NoSuchElementException();
+        }
+        return page.get(indexInPage++);
+      }
+    };
+
+    Spliterator<U> spliterator =
+        Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED | Spliterator.NONNULL);
+    return StreamSupport.stream(spliterator, false);
   }
 
   public Object executeResult(ResultType resultType) {

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/HistoricVariableInstanceQueryImpl.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/HistoricVariableInstanceQueryImpl.java
@@ -21,6 +21,7 @@ import static org.cibseven.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.cibseven.bpm.engine.history.HistoricVariableInstance;
 import org.cibseven.bpm.engine.history.HistoricVariableInstanceQuery;
@@ -313,6 +314,13 @@ public class HistoricVariableInstanceQueryImpl extends AbstractQuery<HistoricVar
   public HistoricVariableInstanceQuery orderByCreationTime() {
     orderBy(HistoricVariableInstanceQueryProperty.CREATE_TIME);
     return this;
+  }
+
+  public Stream<HistoricVariableInstance> streamStable() {
+    return streamByKeyset(
+        HistoricVariableInstance::getId,
+        this::idAfter,
+        () -> { orderByVariableId(); asc(); });
   }
 
   // getters and setters //////////////////////////////////////////////////////

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/HistoricVariableInstanceQueryImpl.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/HistoricVariableInstanceQueryImpl.java
@@ -316,7 +316,10 @@ public class HistoricVariableInstanceQueryImpl extends AbstractQuery<HistoricVar
     return this;
   }
 
+  
+  @Override
   public Stream<HistoricVariableInstance> streamStable() {
+    // keyset pagination by variable id: no duplicates, no missing entries under concurrent changes
     return streamByKeyset(
         HistoricVariableInstance::getId,
         this::idAfter,

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/VariableInstanceQueryImpl.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/VariableInstanceQueryImpl.java
@@ -40,13 +40,6 @@ public class VariableInstanceQueryImpl extends AbstractVariableQueryImpl<Variabl
 
   private static final long serialVersionUID = 1L;
 
-  /**
-   * Only used internally by {@link #stream()} for keyset (seek) pagination: when set, only
-   * variable instances with an id greater than this value are selected. Not exposed as a public
-   * query filter since the id is a random UUID and "greater than" has no meaningful semantics for
-   * a caller - it only serves as an internal cursor to fetch "the next batch after what has
-   * already been streamed", independent of the actual result-set position.
-   */
   protected String variableIdGreaterThan;
 
   protected String variableId;
@@ -177,20 +170,7 @@ public class VariableInstanceQueryImpl extends AbstractVariableQueryImpl<Variabl
     return this;
   }
 
-  // streaming ////////////////////////////////////////////////////
-
-  /**
-   * Overrides the default {@link org.cibseven.bpm.engine.query.Query#stream()} with the keyset
-   * (seek) pagination provided by {@link #streamByKeyset(Function, Consumer, Runnable)}, instead
-   * of the default's OFFSET-based pagination - see that method for the full rationale.
-   *
-   * <p>Note that variable instance ids are time-based UUIDs whose string form is not
-   * chronologically ordered, and OFFSET-based pagination is vulnerable to concurrent writes
-   * regardless of ordering, so this is not a theoretical concern: concurrent writes are common
-   * while a long-running stream over variable instances is consumed.
-   */
-  @Override
-  public Stream<VariableInstance> stream() {
+  public Stream<VariableInstance> streamStable() {
     return streamByKeyset(
         VariableInstance::getId,
         idGreaterThan -> this.variableIdGreaterThan = idGreaterThan,

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/VariableInstanceQueryImpl.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/VariableInstanceQueryImpl.java
@@ -20,6 +20,7 @@ import static org.cibseven.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.cibseven.bpm.engine.impl.cmd.CommandLogger;
 import org.cibseven.bpm.engine.impl.interceptor.CommandContext;
@@ -38,6 +39,15 @@ public class VariableInstanceQueryImpl extends AbstractVariableQueryImpl<Variabl
   private final static CommandLogger LOG = ProcessEngineLogger.CMD_LOGGER;
 
   private static final long serialVersionUID = 1L;
+
+  /**
+   * Only used internally by {@link #stream()} for keyset (seek) pagination: when set, only
+   * variable instances with an id greater than this value are selected. Not exposed as a public
+   * query filter since the id is a random UUID and "greater than" has no meaningful semantics for
+   * a caller - it only serves as an internal cursor to fetch "the next batch after what has
+   * already been streamed", independent of the actual result-set position.
+   */
+  protected String variableIdGreaterThan;
 
   protected String variableId;
   protected String variableName;
@@ -165,6 +175,30 @@ public class VariableInstanceQueryImpl extends AbstractVariableQueryImpl<Variabl
   public VariableInstanceQuery orderByTenantId() {
     orderBy(VariableInstanceQueryProperty.TENANT_ID);
     return this;
+  }
+
+  // streaming ////////////////////////////////////////////////////
+
+  /**
+   * Overrides the default {@link org.cibseven.bpm.engine.query.Query#stream()} with the keyset
+   * (seek) pagination provided by {@link #streamByKeyset(Function, Consumer, Runnable)}, instead
+   * of the default's OFFSET-based pagination - see that method for the full rationale.
+   *
+   * <p>Note that variable instance ids are time-based UUIDs whose string form is not
+   * chronologically ordered, and OFFSET-based pagination is vulnerable to concurrent writes
+   * regardless of ordering, so this is not a theoretical concern: concurrent writes are common
+   * while a long-running stream over variable instances is consumed.
+   */
+  @Override
+  public Stream<VariableInstance> stream() {
+    return streamByKeyset(
+        VariableInstance::getId,
+        idGreaterThan -> this.variableIdGreaterThan = idGreaterThan,
+        () -> { orderByVariableId(); asc(); });
+  }
+
+  public String getVariableIdGreaterThan() {
+    return variableIdGreaterThan;
   }
 
   @Override

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/VariableInstanceQueryImpl.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/VariableInstanceQueryImpl.java
@@ -39,7 +39,11 @@ public class VariableInstanceQueryImpl extends AbstractVariableQueryImpl<Variabl
   private final static CommandLogger LOG = ProcessEngineLogger.CMD_LOGGER;
 
   private static final long serialVersionUID = 1L;
-
+  
+/**
+ * Only used internally by {@link #stream()} for keyset (seek) pagination. Not exposed as a public
+ * query filter since the id is a random UUID and "greater than" has no meaningful semantics
+ */
   protected String variableIdGreaterThan;
 
   protected String variableId;
@@ -170,6 +174,7 @@ public class VariableInstanceQueryImpl extends AbstractVariableQueryImpl<Variabl
     return this;
   }
 
+  @Override
   public Stream<VariableInstance> streamStable() {
     return streamByKeyset(
         VariableInstance::getId,

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/VariableInstanceQueryImpl.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/VariableInstanceQueryImpl.java
@@ -142,6 +142,11 @@ public class VariableInstanceQueryImpl extends AbstractVariableQueryImpl<Variabl
 
   // ordering ////////////////////////////////////////////////////
 
+  public VariableInstanceQuery orderByVariableId() {
+    orderBy(VariableInstanceQueryProperty.VARIABLE_ID);
+    return this;
+  }
+
   public VariableInstanceQuery orderByVariableName() {
     orderBy(VariableInstanceQueryProperty.VARIABLE_NAME);
     return this;

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/VariableInstanceQueryProperty.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/VariableInstanceQueryProperty.java
@@ -23,6 +23,7 @@ import org.cibseven.bpm.engine.query.QueryProperty;
  */
 public interface VariableInstanceQueryProperty {
 
+  public static final QueryProperty VARIABLE_ID = new QueryPropertyImpl("ID_");
   public static final QueryProperty VARIABLE_NAME = new QueryPropertyImpl("NAME_");
   public static final QueryProperty VARIABLE_TYPE = new QueryPropertyImpl("TYPE_");
   public static final QueryProperty ACTIVITY_INSTANCE_ID = new QueryPropertyImpl("ACT_INST_ID_");

--- a/engine/src/main/java/org/cibseven/bpm/engine/query/Query.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/query/Query.java
@@ -16,7 +16,13 @@
  */
 package org.cibseven.bpm.engine.query;
 
+import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import org.cibseven.bpm.engine.BadUserRequestException;
 import org.cibseven.bpm.engine.ProcessEngineException;
@@ -82,5 +88,69 @@ public interface Query<T extends Query< ? , ? >, U extends Object> {
    *   (default {@link Integer#MAX_VALUE}).
    */
   List<U> listPage(int firstResult, int maxResults);
+
+  /**
+   * Executes the query and returns the results as a lazily evaluated {@link Stream}.
+   *
+   * <p>The stream fetches the results in fixed-size pages from the database on demand (via
+   * {@link #listPage(int, int)}) as it is consumed, so the whole result set is never held in
+   * memory at once. This is a convenience over paginating manually with
+   * {@link #listPage(int, int)}.
+   *
+   * <p><b>Ordering matters:</b> because the results are fetched page by page, the query must
+   * define a <em>stable total order</em> - i.e. an ordering on a unique property (such as the
+   * entity id) - otherwise rows may be duplicated or skipped between pages, just like with
+   * manual pagination. Non-unique orderings (or no ordering at all) do not guarantee a stable
+   * order between page requests.
+   *
+   * <p>Each page is fetched in its own transaction, so the stream does not observe a single
+   * consistent snapshot: concurrent modifications happening while the stream is being consumed
+   * may or may not be reflected. The stream is sequential and should be consumed once.
+   *
+   * @return a lazily evaluated stream of results
+   * @throws BadUserRequestException
+   *   see {@link #listPage(int, int)}
+   */
+  default Stream<U> stream() {
+    final int pageSize = 100;
+
+    Iterator<U> iterator = new Iterator<U>() {
+
+      protected int nextFirstResult = 0;
+      protected List<U> page = null;
+      protected int indexInPage = 0;
+      protected boolean lastPageReached = false;
+
+      @Override
+      public boolean hasNext() {
+        if (page != null && indexInPage < page.size()) {
+          return true;
+        }
+        if (lastPageReached) {
+          return false;
+        }
+        page = listPage(nextFirstResult, pageSize);
+        nextFirstResult += pageSize;
+        indexInPage = 0;
+        // a page smaller than the requested size means there are no further pages
+        if (page.size() < pageSize) {
+          lastPageReached = true;
+        }
+        return indexInPage < page.size();
+      }
+
+      @Override
+      public U next() {
+        if (!hasNext()) {
+          throw new NoSuchElementException();
+        }
+        return page.get(indexInPage++);
+      }
+    };
+
+    Spliterator<U> spliterator =
+        Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED | Spliterator.NONNULL);
+    return StreamSupport.stream(spliterator, false);
+  }
 
 }

--- a/engine/src/main/java/org/cibseven/bpm/engine/runtime/VariableInstanceQuery.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/runtime/VariableInstanceQuery.java
@@ -224,6 +224,9 @@ public interface VariableInstanceQuery extends Query<VariableInstanceQuery, Vari
    */
   VariableInstanceQuery tenantIdIn(String... tenantIds);
 
+    /**
+   * Order by the id of the variable instance (needs to be followed by {@link #asc()} or {@link #desc()}).
+   */
   VariableInstanceQuery orderByVariableId();
 
   /**

--- a/engine/src/main/java/org/cibseven/bpm/engine/runtime/VariableInstanceQuery.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/runtime/VariableInstanceQuery.java
@@ -17,6 +17,7 @@
 package org.cibseven.bpm.engine.runtime;
 
 import java.io.Serializable;
+import java.util.stream.Stream;
 
 import org.cibseven.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.cibseven.bpm.engine.query.Query;
@@ -223,15 +224,6 @@ public interface VariableInstanceQuery extends Query<VariableInstanceQuery, Vari
    */
   VariableInstanceQuery tenantIdIn(String... tenantIds);
 
-  /**
-   * Order by the id of the variable instance (needs to be followed by {@link #asc()} or {@link #desc()}).
-   *
-   * <p>Since the variable instance id is unique, ordering by it yields a stable total order.
-   * This is the recommended ordering when paginating over the result (e.g. via
-   * {@link #listPage(int, int)}): non-unique orderings such as {@link #orderByVariableName()}
-   * do not guarantee a stable order between page requests, so rows may be duplicated or
-   * skipped across pages. Ordering by the (unique) variable instance id avoids this.
-   */
   VariableInstanceQuery orderByVariableId();
 
   /**
@@ -254,5 +246,7 @@ public interface VariableInstanceQuery extends Query<VariableInstanceQuery, Vari
    * Note that the ordering of variable instances without tenant id is database-specific.
    */
   VariableInstanceQuery orderByTenantId();
+
+  Stream<VariableInstance> streamStable();
 
 }

--- a/engine/src/main/java/org/cibseven/bpm/engine/runtime/VariableInstanceQuery.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/runtime/VariableInstanceQuery.java
@@ -224,6 +224,17 @@ public interface VariableInstanceQuery extends Query<VariableInstanceQuery, Vari
   VariableInstanceQuery tenantIdIn(String... tenantIds);
 
   /**
+   * Order by the id of the variable instance (needs to be followed by {@link #asc()} or {@link #desc()}).
+   *
+   * <p>Since the variable instance id is unique, ordering by it yields a stable total order.
+   * This is the recommended ordering when paginating over the result (e.g. via
+   * {@link #listPage(int, int)}): non-unique orderings such as {@link #orderByVariableName()}
+   * do not guarantee a stable order between page requests, so rows may be duplicated or
+   * skipped across pages. Ordering by the (unique) variable instance id avoids this.
+   */
+  VariableInstanceQuery orderByVariableId();
+
+  /**
    * Order by variable name (needs to be followed by {@link #asc()} or {@link #desc()}).
    */
   VariableInstanceQuery orderByVariableName();

--- a/engine/src/main/resources/org/cibseven/bpm/engine/impl/mapping/entity/VariableInstance.xml
+++ b/engine/src/main/resources/org/cibseven/bpm/engine/impl/mapping/entity/VariableInstance.xml
@@ -343,6 +343,11 @@
               RES.ID_ = #{variableId}
             </if>
 
+            <!-- variableIdGreaterThan: internal keyset-pagination cursor used by Query#stream() -->
+            <if test="variableIdGreaterThan != null">
+              and RES.ID_ &gt; #{variableIdGreaterThan}
+            </if>
+
             <!-- variableName -->
             <if test="variableName != null">
               and RES.NAME_ = #{variableName}

--- a/engine/src/main/resources/org/cibseven/bpm/engine/impl/mapping/entity/VariableInstance.xml
+++ b/engine/src/main/resources/org/cibseven/bpm/engine/impl/mapping/entity/VariableInstance.xml
@@ -343,7 +343,7 @@
               RES.ID_ = #{variableId}
             </if>
 
-            <!-- variableIdGreaterThan: internal keyset-pagination cursor used by Query#stream() -->
+            <!-- variableIdGreaterThan -->
             <if test="variableIdGreaterThan != null">
               and RES.ID_ &gt; #{variableIdGreaterThan}
             </if>

--- a/engine/src/test/java/org/cibseven/bpm/engine/test/api/queries/QueryByIdAfterTest.java
+++ b/engine/src/test/java/org/cibseven/bpm/engine/test/api/queries/QueryByIdAfterTest.java
@@ -17,11 +17,15 @@
 package org.cibseven.bpm.engine.test.api.queries;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.cibseven.bpm.engine.HistoryService;
 import org.cibseven.bpm.engine.ProcessEngineConfiguration;
 import org.cibseven.bpm.engine.RuntimeService;
@@ -79,6 +83,56 @@ public class QueryByIdAfterTest {
     List<HistoricVariableInstance> secondHalf = historicVariableInstanceQuery.idAfter(middleId).list();
     assertEquals(10, secondHalf.size());
     assertTrue(secondHalf.stream().allMatch(variable -> isIdGreaterThan(variable.getId(), middleId)));
+  }
+
+  @Test
+  @Deployment(resources = { "org/cibseven/bpm/engine/test/history/HistoricVariableInstanceTest.testSimple.bpmn20.xml" })
+  public void shouldStreamStableBeRobustAgainstConcurrentModifications() {
+    // given
+    int variableCount = 250;
+    startProcessInstancesByKey("myProc", variableCount / 2);
+
+    List<HistoricVariableInstance> before = historyService.createHistoricVariableInstanceQuery()
+        .orderByVariableId().asc().list();
+    assertEquals(variableCount, before.size());
+
+    // when
+    Iterator<HistoricVariableInstance> iterator = historyService.createHistoricVariableInstanceQuery()
+        .streamStable().iterator();
+
+    Set<String> streamedIds = new HashSet<>();
+    int firstBatchSize = 100;
+    for (int i = 0; i < firstBatchSize; i++) {
+      assertTrue(iterator.hasNext());
+      streamedIds.add(iterator.next().getId());
+    }
+    assertEquals(firstBatchSize, streamedIds.size());
+
+    String notYetStreamedId = null;
+    for (HistoricVariableInstance historicVariableInstance : before) {
+      if (!streamedIds.contains(historicVariableInstance.getId())) {
+        notYetStreamedId = historicVariableInstance.getId();
+        break;
+      }
+    }
+    assertNotNull(notYetStreamedId);
+    historyService.deleteHistoricVariableInstance(notYetStreamedId);
+
+    startProcessInstancesByKey("myProc", 25);
+
+    // then
+    while (iterator.hasNext()) {
+      HistoricVariableInstance historicVariableInstance = iterator.next();
+      assertTrue("historic variable instance " + historicVariableInstance.getId() + " was streamed more than once",
+          streamedIds.add(historicVariableInstance.getId()));
+    }
+
+    for (HistoricVariableInstance historicVariableInstance : before) {
+      if (!historicVariableInstance.getId().equals(notYetStreamedId)) {
+        assertTrue("historic variable instance " + historicVariableInstance.getId() + " was not streamed",
+            streamedIds.contains(historicVariableInstance.getId()));
+      }
+    }
   }
 
   private void startProcessInstancesByKey(String key, int numberOfInstances) {

--- a/engine/src/test/java/org/cibseven/bpm/engine/test/api/runtime/VariableInstanceQueryTest.java
+++ b/engine/src/test/java/org/cibseven/bpm/engine/test/api/runtime/VariableInstanceQueryTest.java
@@ -1933,6 +1933,158 @@ public class VariableInstanceQueryTest extends PluggableProcessEngineTest {
 
   @Test
   @Deployment(resources={"org/cibseven/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
+  public void testQueryOrderByVariableId_Asc() {
+    // given
+    Map<String, Object> variables = new HashMap<>();
+    variables.put("stringVar", "test");
+    variables.put("myVar", "test123");
+    runtimeService.startProcessInstanceByKey(PROC_DEF_KEY, variables);
+
+    // when
+    List<VariableInstance> result = runtimeService.createVariableInstanceQuery()
+        .orderByVariableId().asc().list();
+
+    // then
+    assertEquals(2, result.size());
+
+    List<String> expectedIds = new ArrayList<>();
+    for (VariableInstance variableInstance : result) {
+      expectedIds.add(variableInstance.getId());
+    }
+    Collections.sort(expectedIds);
+
+    assertEquals(expectedIds.get(0), result.get(0).getId());
+    assertEquals(expectedIds.get(1), result.get(1).getId());
+  }
+
+  @Test
+  @Deployment(resources={"org/cibseven/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
+  public void testQueryOrderByVariableId_Desc() {
+    // given
+    Map<String, Object> variables = new HashMap<>();
+    variables.put("stringVar", "test");
+    variables.put("myVar", "test123");
+    runtimeService.startProcessInstanceByKey(PROC_DEF_KEY, variables);
+
+    // when
+    List<VariableInstance> result = runtimeService.createVariableInstanceQuery()
+        .orderByVariableId().desc().list();
+
+    // then
+    assertEquals(2, result.size());
+
+    List<String> expectedIds = new ArrayList<>();
+    for (VariableInstance variableInstance : result) {
+      expectedIds.add(variableInstance.getId());
+    }
+    Collections.sort(expectedIds, Collections.reverseOrder());
+
+    assertEquals(expectedIds.get(0), result.get(0).getId());
+    assertEquals(expectedIds.get(1), result.get(1).getId());
+  }
+
+  @Test
+  @Deployment(resources={"org/cibseven/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
+  public void testQueryOrderByVariableIdStablePagination() {
+    // given a number of variable instances
+    Map<String, Object> variables = new HashMap<>();
+    for (int i = 0; i < 10; i++) {
+      variables.put("var" + i, "value" + i);
+    }
+    runtimeService.startProcessInstanceByKey(PROC_DEF_KEY, variables);
+
+    long count = runtimeService.createVariableInstanceQuery().count();
+    assertEquals(10, count);
+
+    // when paginating over the result ordered by the (unique) variable id
+    Set<String> collectedIds = new HashSet<>();
+    int pageSize = 3;
+    for (int firstResult = 0; firstResult < count; firstResult += pageSize) {
+      List<VariableInstance> page = runtimeService.createVariableInstanceQuery()
+          .orderByVariableId().asc()
+          .listPage(firstResult, pageSize);
+
+      for (VariableInstance variableInstance : page) {
+        // then no row is returned twice across pages
+        assertTrue("variable instance " + variableInstance.getId() + " was returned on more than one page",
+            collectedIds.add(variableInstance.getId()));
+      }
+    }
+
+    // then every row is returned exactly once (no missing rows)
+    assertEquals(10, collectedIds.size());
+  }
+
+  @Test
+  @Deployment(resources={"org/cibseven/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
+  public void testStreamMatchesList() {
+    // given
+    Map<String, Object> variables = new HashMap<>();
+    variables.put("stringVar", "test");
+    variables.put("myVar", "test123");
+    runtimeService.startProcessInstanceByKey(PROC_DEF_KEY, variables);
+
+    // when
+    List<String> streamedIds = new ArrayList<>();
+    runtimeService.createVariableInstanceQuery()
+        .orderByVariableId().asc()
+        .stream()
+        .forEach(variableInstance -> streamedIds.add(variableInstance.getId()));
+
+    List<String> listedIds = new ArrayList<>();
+    for (VariableInstance variableInstance : runtimeService.createVariableInstanceQuery()
+        .orderByVariableId().asc().list()) {
+      listedIds.add(variableInstance.getId());
+    }
+
+    // then the lazily streamed result is identical to list()
+    assertEquals(listedIds, streamedIds);
+  }
+
+  @Test
+  @Deployment(resources={"org/cibseven/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
+  public void testStreamPaginatesAcrossPages() {
+    // given more variable instances than the internal stream page size (100)
+    int variableCount = 250;
+    Map<String, Object> variables = new HashMap<>();
+    for (int i = 0; i < variableCount; i++) {
+      variables.put("var" + i, "value" + i);
+    }
+    runtimeService.startProcessInstanceByKey(PROC_DEF_KEY, variables);
+
+    assertEquals(variableCount, runtimeService.createVariableInstanceQuery().count());
+
+    // when consuming the whole result set as a stream (ordered by the unique id)
+    Set<String> streamedIds = new HashSet<>();
+    runtimeService.createVariableInstanceQuery()
+        .orderByVariableId().asc()
+        .stream()
+        .forEach(variableInstance ->
+            // then no row is streamed twice across the internally fetched pages
+            assertTrue("variable instance " + variableInstance.getId() + " was streamed more than once",
+                streamedIds.add(variableInstance.getId())));
+
+    // then every row is streamed exactly once (no missing rows)
+    assertEquals(variableCount, streamedIds.size());
+  }
+
+  @Test
+  @Deployment(resources={"org/cibseven/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
+  public void testStreamOnEmptyResult() {
+    // given no variable instances
+
+    // when
+    long streamedCount = runtimeService.createVariableInstanceQuery()
+        .orderByVariableId().asc()
+        .stream()
+        .count();
+
+    // then
+    assertEquals(0, streamedCount);
+  }
+
+  @Test
+  @Deployment(resources={"org/cibseven/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
   public void testQueryOrderByType_Asc() {
     // given
     Map<String, Object> variables = new HashMap<>();

--- a/engine/src/test/java/org/cibseven/bpm/engine/test/api/runtime/VariableInstanceQueryTest.java
+++ b/engine/src/test/java/org/cibseven/bpm/engine/test/api/runtime/VariableInstanceQueryTest.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -2066,6 +2067,70 @@ public class VariableInstanceQueryTest extends PluggableProcessEngineTest {
 
     // then every row is streamed exactly once (no missing rows)
     assertEquals(variableCount, streamedIds.size());
+  }
+
+  @Test
+  @Deployment(resources={"org/cibseven/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
+  public void testStreamIsRobustAgainstConcurrentModifications() {
+    // given more variable instances than the internal stream page size (100)
+    int variableCount = 250;
+    Map<String, Object> variables = new HashMap<>();
+    for (int i = 0; i < variableCount; i++) {
+      variables.put("var" + i, "value" + i);
+    }
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(PROC_DEF_KEY, variables);
+
+    // a snapshot of every variable instance that exists before streaming starts
+    List<VariableInstance> before = runtimeService.createVariableInstanceQuery()
+        .orderByVariableId().asc().list();
+    assertEquals(variableCount, before.size());
+
+    // when starting to consume the stream, but stopping after exactly the first internal
+    // page (100 rows) to simulate concurrent writes happening while the stream is still open
+    Iterator<VariableInstance> iterator = runtimeService.createVariableInstanceQuery().stream().iterator();
+
+    Set<String> streamedIds = new HashSet<>();
+    int firstBatchSize = 100;
+    for (int i = 0; i < firstBatchSize; i++) {
+      assertTrue(iterator.hasNext());
+      streamedIds.add(iterator.next().getId());
+    }
+    assertEquals(firstBatchSize, streamedIds.size());
+
+    // delete a variable instance that has definitely not been streamed yet
+    String notYetStreamedVariableName = null;
+    for (VariableInstance variableInstance : before) {
+      if (!streamedIds.contains(variableInstance.getId())) {
+        notYetStreamedVariableName = variableInstance.getName();
+        break;
+      }
+    }
+    assertNotNull(notYetStreamedVariableName);
+    runtimeService.removeVariable(processInstance.getId(), notYetStreamedVariableName);
+
+    // and insert new variable instances, simulating writes happening concurrently
+    // to the stream being consumed
+    for (int i = 0; i < 50; i++) {
+      runtimeService.setVariable(processInstance.getId(), "concurrentVar" + i, "value");
+    }
+
+    // then continuing to consume the rest of the stream does not return any row twice,
+    // even though the table was modified while the stream was open
+    while (iterator.hasNext()) {
+      VariableInstance variableInstance = iterator.next();
+      assertTrue("variable instance " + variableInstance.getId() + " was streamed more than once",
+          streamedIds.add(variableInstance.getId()));
+    }
+
+    // and every variable instance that existed before streaming started - except the one
+    // deleted concurrently - was streamed exactly once, unaffected by the concurrent
+    // insertions/deletions. Offset-based pagination cannot provide this guarantee.
+    for (VariableInstance variableInstance : before) {
+      if (!variableInstance.getName().equals(notYetStreamedVariableName)) {
+        assertTrue("variable instance " + variableInstance.getId() + " (" + variableInstance.getName() + ") was not streamed",
+            streamedIds.contains(variableInstance.getId()));
+      }
+    }
   }
 
   @Test

--- a/engine/src/test/java/org/cibseven/bpm/engine/test/api/runtime/VariableInstanceQueryTest.java
+++ b/engine/src/test/java/org/cibseven/bpm/engine/test/api/runtime/VariableInstanceQueryTest.java
@@ -1987,7 +1987,7 @@ public class VariableInstanceQueryTest extends PluggableProcessEngineTest {
   @Test
   @Deployment(resources={"org/cibseven/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
   public void testQueryOrderByVariableIdStablePagination() {
-    // given a number of variable instances
+    // given
     Map<String, Object> variables = new HashMap<>();
     for (int i = 0; i < 10; i++) {
       variables.put("var" + i, "value" + i);
@@ -1997,7 +1997,7 @@ public class VariableInstanceQueryTest extends PluggableProcessEngineTest {
     long count = runtimeService.createVariableInstanceQuery().count();
     assertEquals(10, count);
 
-    // when paginating over the result ordered by the (unique) variable id
+    // when
     Set<String> collectedIds = new HashSet<>();
     int pageSize = 3;
     for (int firstResult = 0; firstResult < count; firstResult += pageSize) {
@@ -2006,13 +2006,12 @@ public class VariableInstanceQueryTest extends PluggableProcessEngineTest {
           .listPage(firstResult, pageSize);
 
       for (VariableInstance variableInstance : page) {
-        // then no row is returned twice across pages
         assertTrue("variable instance " + variableInstance.getId() + " was returned on more than one page",
             collectedIds.add(variableInstance.getId()));
       }
     }
 
-    // then every row is returned exactly once (no missing rows)
+    // then
     assertEquals(10, collectedIds.size());
   }
 
@@ -2038,14 +2037,14 @@ public class VariableInstanceQueryTest extends PluggableProcessEngineTest {
       listedIds.add(variableInstance.getId());
     }
 
-    // then the lazily streamed result is identical to list()
+    // then
     assertEquals(listedIds, streamedIds);
   }
 
   @Test
   @Deployment(resources={"org/cibseven/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
   public void testStreamPaginatesAcrossPages() {
-    // given more variable instances than the internal stream page size (100)
+    // given
     int variableCount = 250;
     Map<String, Object> variables = new HashMap<>();
     for (int i = 0; i < variableCount; i++) {
@@ -2055,24 +2054,23 @@ public class VariableInstanceQueryTest extends PluggableProcessEngineTest {
 
     assertEquals(variableCount, runtimeService.createVariableInstanceQuery().count());
 
-    // when consuming the whole result set as a stream (ordered by the unique id)
+    // when
     Set<String> streamedIds = new HashSet<>();
     runtimeService.createVariableInstanceQuery()
         .orderByVariableId().asc()
         .stream()
         .forEach(variableInstance ->
-            // then no row is streamed twice across the internally fetched pages
             assertTrue("variable instance " + variableInstance.getId() + " was streamed more than once",
                 streamedIds.add(variableInstance.getId())));
 
-    // then every row is streamed exactly once (no missing rows)
+    // then
     assertEquals(variableCount, streamedIds.size());
   }
 
   @Test
   @Deployment(resources={"org/cibseven/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
   public void testStreamIsRobustAgainstConcurrentModifications() {
-    // given more variable instances than the internal stream page size (100)
+    // given
     int variableCount = 250;
     Map<String, Object> variables = new HashMap<>();
     for (int i = 0; i < variableCount; i++) {
@@ -2080,14 +2078,12 @@ public class VariableInstanceQueryTest extends PluggableProcessEngineTest {
     }
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(PROC_DEF_KEY, variables);
 
-    // a snapshot of every variable instance that exists before streaming starts
     List<VariableInstance> before = runtimeService.createVariableInstanceQuery()
         .orderByVariableId().asc().list();
     assertEquals(variableCount, before.size());
 
-    // when starting to consume the stream, but stopping after exactly the first internal
-    // page (100 rows) to simulate concurrent writes happening while the stream is still open
-    Iterator<VariableInstance> iterator = runtimeService.createVariableInstanceQuery().stream().iterator();
+    // when
+    Iterator<VariableInstance> iterator = runtimeService.createVariableInstanceQuery().streamStable().iterator();
 
     Set<String> streamedIds = new HashSet<>();
     int firstBatchSize = 100;
@@ -2097,7 +2093,6 @@ public class VariableInstanceQueryTest extends PluggableProcessEngineTest {
     }
     assertEquals(firstBatchSize, streamedIds.size());
 
-    // delete a variable instance that has definitely not been streamed yet
     String notYetStreamedVariableName = null;
     for (VariableInstance variableInstance : before) {
       if (!streamedIds.contains(variableInstance.getId())) {
@@ -2108,23 +2103,17 @@ public class VariableInstanceQueryTest extends PluggableProcessEngineTest {
     assertNotNull(notYetStreamedVariableName);
     runtimeService.removeVariable(processInstance.getId(), notYetStreamedVariableName);
 
-    // and insert new variable instances, simulating writes happening concurrently
-    // to the stream being consumed
     for (int i = 0; i < 50; i++) {
       runtimeService.setVariable(processInstance.getId(), "concurrentVar" + i, "value");
     }
 
-    // then continuing to consume the rest of the stream does not return any row twice,
-    // even though the table was modified while the stream was open
+    // then
     while (iterator.hasNext()) {
       VariableInstance variableInstance = iterator.next();
       assertTrue("variable instance " + variableInstance.getId() + " was streamed more than once",
           streamedIds.add(variableInstance.getId()));
     }
 
-    // and every variable instance that existed before streaming started - except the one
-    // deleted concurrently - was streamed exactly once, unaffected by the concurrent
-    // insertions/deletions. Offset-based pagination cannot provide this guarantee.
     for (VariableInstance variableInstance : before) {
       if (!variableInstance.getName().equals(notYetStreamedVariableName)) {
         assertTrue("variable instance " + variableInstance.getId() + " (" + variableInstance.getName() + ") was not streamed",
@@ -2136,8 +2125,6 @@ public class VariableInstanceQueryTest extends PluggableProcessEngineTest {
   @Test
   @Deployment(resources={"org/cibseven/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
   public void testStreamOnEmptyResult() {
-    // given no variable instances
-
     // when
     long streamedCount = runtimeService.createVariableInstanceQuery()
         .orderByVariableId().asc()


### PR DESCRIPTION

- add orderByVariableId() to runtime VariableInstanceQuery, ordering by the unique primary key (ID_) so paginated results have a stable total order and do not duplicate or skip rows across pages
- expose it via REST (sortBy=variableId) and the OpenAPI sort enum
- add a default Stream<U> stream() to Query<T,U> that lazily paginates via listPage, so all query types can be streamed without manual pagination
- add engine and REST tests for ordering, stable pagination, and streaming