### PR TITLE
fix(connect,tomcat): pin AI-agent Jackson to patched 2.21.4 (CIB7-1426)

### DIFF
--- a/connect/ai-agent/pom.xml
+++ b/connect/ai-agent/pom.xml
@@ -72,8 +72,17 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- JSON serialisation for the chat log persistence — provided by the engine runtime (Spin/REST).
+    <!-- JSON serialisation for the chat log persistence (AgentChatListener / AgentConnectorImpl
+         use ObjectMapper, JsonProcessingException and TypeReference directly, so jackson-core and
+         jackson-databind are first-order dependencies of this module — see dependency:analyze).
+         provided: the engine host supplies Jackson at runtime (Spin/REST), so we don't bundle it.
          Version pinned to the cibseven-parent property so it stays in lockstep with the engine. -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>${version.jackson}</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>

--- a/distro/tomcat/ai-agent/pom.xml
+++ b/distro/tomcat/ai-agent/pom.xml
@@ -20,6 +20,29 @@
     <skip-third-party-bom>false</skip-third-party-bom>
   </properties>
 
+  <!-- CIB7-1426: langchain4j 1.16.3 transitively pulls jackson-core/databind 2.21.3
+       (CVE-2026-54512 / CVE-2026-54513), fixed in 2.21.4. Tomcat is the ONLY distro
+       where langchain4j's Jackson is authoritative on the runtime classpath: the
+       overlay's jars are the sole jackson-core/databind on the lib-ai/ common.loader
+       (run/run4 let the spring-boot BOM govern, wildfly the JBoss module). So the
+       version is forced here — local to the Tomcat distro — rather than in the shared
+       parent, which would raise the "then pin it in the run starter too" question.
+       Tracks ${version.jackson} so a future CVE bump flows through a single knob. -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>${version.jackson}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${version.jackson}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
 
     <dependency>
@@ -61,6 +84,38 @@
                    never leak into this execution. -->
               <outputDirectory>${project.build.directory}/dependency</outputDirectory>
               <includeScope>runtime</includeScope>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- CIB7-1426 guard: the pin above forces Jackson to ${version.jackson}. This
+           fails the build if langchain4j (or any other overlay dep) ever REQUIRES a
+           jackson-core/databind newer than what we ship — i.e. it detects a silent
+           downgrade rather than a CVE. Scoped to Jackson only, so the langchain4j /
+           ONNX / pdfbox tree is not otherwise subjected to convergence checks. When
+           it fires, bump ${version.jackson} to a version that satisfies langchain4j
+           (and stays in sync with the spring-boot BOM the other distros use). -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.5.0</version>
+        <executions>
+          <execution>
+            <id>enforce-jackson-not-downgraded</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireUpperBoundDeps>
+                  <includes>
+                    <include>com.fasterxml.jackson.core:jackson-core</include>
+                    <include>com.fasterxml.jackson.core:jackson-databind</include>
+                  </includes>
+                </requireUpperBoundDeps>
+              </rules>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
## Jira
CIB7-1426 — Fix CVEs found in CIB seven 2.2.0 with the harbor

## Problem
The AI-agent connector pulls in **langchain4j 1.16.3**, which transitively brings **jackson-core / jackson-databind 2.21.3** — vulnerable to **CVE-2026-54512 / CVE-2026-54513** (fixed in 2.21.4).

Only the **Tomcat** distro actually shipped the vulnerable jar. All distros include the AI-agent, but Jackson resolution differs:

| Distro | How Jackson is governed | Result |
|---|---|---|
| run / run4 | imports the `spring-boot-dependencies` BOM | Spring's secured version overrides langchain4j's 2.21.3 → not vulnerable |
| wildfly | Jackson is a JBoss module (`module.xml`) | transitive jar ignored at runtime → not vulnerable |
| **tomcat** | ai-agent overlay copies langchain4j's transitive jars onto the `lib-ai/` common.loader, and **nothing governs Jackson there** | ships `jackson-core 2.21.3` verbatim → **vulnerable** |

## Fix (two parts)
**`distro/tomcat/ai-agent/pom.xml`** — the actual CVE fix, kept **local to the affected distro** (nothing pinned in the shared parent or the run starter, so run/run4/wildfly governance is untouched):
- `dependencyManagement` forces `jackson-core` / `jackson-databind` to `${version.jackson}` → overlay now ships **2.21.4**.
- `maven-enforcer` `requireUpperBoundDeps` (scoped to Jackson) fails the build if langchain4j ever *requires* a newer Jackson than we ship — detects a silent downgrade instead of freezing a literal.

**`connect/ai-agent/pom.xml`** — dependency hygiene at the source:
- Declare `jackson-core` explicitly (was *used-undeclared* via langchain4j) alongside the existing `jackson-databind`, both `provided` at `${version.jackson}` — `AgentChatListener` / `AgentConnectorImpl` use `ObjectMapper` / `TypeReference` directly.

## Verification
- Tomcat overlay `dependency:tree`: `jackson-core:2.21.4`, `jackson-databind:2.21.4`.
- Enforcer verified both directions: passes normally, fails on a forced downgrade.
- `connect/ai-agent` `dependency:analyze` (via `maven-dependency-plugin:3.7.0`): no undeclared/unused Jackson warnings.

## Maintenance
A future CVE bump = update the single `version.jackson` property; the enforcer flags if it ever falls behind what langchain4j needs. No frozen literal — it tracks the engine / Spring-secured line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)