### PR TITLE
fix(rest): add charset to Content-Type for rendered form endpoint

### DIFF
--- a/engine-rest/engine-rest/src/main/java/org/cibseven/bpm/engine/rest/sub/repository/impl/ProcessDefinitionResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/cibseven/bpm/engine/rest/sub/repository/impl/ProcessDefinitionResourceImpl.java
@@ -344,7 +344,7 @@ public class ProcessDefinitionResourceImpl implements ProcessDefinitionResource 
       InputStream stream = new ByteArrayInputStream(content.getBytes(EncodingUtil.DEFAULT_ENCODING));
       return Response
           .ok(stream)
-          .type(MediaType.APPLICATION_XHTML_XML)
+          .type(MediaType.APPLICATION_XHTML_XML + ";charset=UTF-8")
           .build();
     }
 

--- a/engine-rest/engine-rest/src/main/java/org/cibseven/bpm/engine/rest/sub/task/impl/TaskResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/cibseven/bpm/engine/rest/sub/task/impl/TaskResourceImpl.java
@@ -281,7 +281,7 @@ public class TaskResourceImpl implements TaskResource {
       InputStream stream = new ByteArrayInputStream(content.getBytes(EncodingUtil.DEFAULT_ENCODING));
       return Response
           .ok(stream)
-          .type(MediaType.APPLICATION_XHTML_XML)
+          .type(MediaType.APPLICATION_XHTML_XML + ";charset=UTF-8")
           .build();
     }
 


### PR DESCRIPTION
- Adds ;charset=UTF-8 to MediaType in TaskResourceImpl#getRenderedForm()
- Prevents garbled display of non-ASCII characters in browsers
- Adds test to verify Content-Type header includes charset

related to #390