### PR TITLE
chore: switch Jenkins back to JDK17

### DIFF
--- a/Jenkinsfile.cib
+++ b/Jenkinsfile.cib
@@ -12,12 +12,12 @@ import groovy.transform.Field
 @Field String mavenLocalRepoRedirected = null
 @Field Map pipelineParams = [
     pom: ConstantsInternal.DEFAULT_MAVEN_POM_PATH,
-    mvnContainerName: Constants.MAVEN_JDK_21_CONTAINER,
+    mvnContainerName: Constants.MAVEN_JDK_17_CONTAINER,
     uiParamPresets: [:],
     testMode: false,
     dependencyTrackSynchronous: true,
     buildPodConfig: [
-        (Constants.MAVEN_JDK_21_CONTAINER): [
+        (Constants.MAVEN_JDK_17_CONTAINER): [
             resources: [
                 cpu: '4',
                 memory: '16Gi',


### PR DESCRIPTION
revert previous update: a few tests are failing with JDK21