### PR TITLE
fix(engine): add authorization checks to attachment commands (CIB7-1752)

### DIFF
--- a/engine-rest/engine-rest/src/main/java/org/cibseven/bpm/engine/rest/sub/task/impl/TaskAttachmentResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/cibseven/bpm/engine/rest/sub/task/impl/TaskAttachmentResourceImpl.java
@@ -27,6 +27,7 @@ import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import org.cibseven.bpm.engine.AuthorizationException;
 import org.cibseven.bpm.engine.IdentityService;
 import org.cibseven.bpm.engine.ProcessEngine;
 import org.cibseven.bpm.engine.ProcessEngineException;
@@ -104,6 +105,8 @@ public class TaskAttachmentResourceImpl implements TaskAttachmentResource {
 
     try {
       engine.getTaskService().deleteTaskAttachment(taskId, attachmentId);
+    } catch (AuthorizationException e) {
+      throw e;
     } catch (ProcessEngineException e) {
       throw new InvalidRequestException(Status.NOT_FOUND, "Deletion is not possible. No attachment exists for task id '" + taskId + "' and attachment id '" + attachmentId + "'.");
     }
@@ -145,6 +148,8 @@ public class TaskAttachmentResourceImpl implements TaskAttachmentResource {
       } else if (urlPart != null) {
         attachment = engine.getTaskService().createAttachment(attachmentType, taskId, null, attachmentName, attachmentDescription, urlPart.getTextContent());
       }
+    } catch (AuthorizationException e) {
+      throw e;
     } catch (ProcessEngineException e) {
       throw new InvalidRequestException(Status.BAD_REQUEST, e, "Task id is null");
     }

--- a/engine-rest/engine-rest/src/test/java/org/cibseven/bpm/engine/rest/TaskRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/cibseven/bpm/engine/rest/TaskRestServiceInteractionTest.java
@@ -3083,6 +3083,121 @@ public class TaskRestServiceInteractionTest extends
   }
 
   @Test
+  public void testDeleteSingleTaskAttachmentThrowsAuthorizationException() {
+    String message = "expected exception";
+    doThrow(new AuthorizationException(message)).when(taskServiceMock)
+        .deleteTaskAttachment(EXAMPLE_TASK_ID, EXAMPLE_TASK_ATTACHMENT_ID);
+
+    given()
+      .pathParam("id", EXAMPLE_TASK_ID)
+      .pathParam("attachmentId", EXAMPLE_TASK_ATTACHMENT_ID)
+      .header("accept", MediaType.APPLICATION_JSON)
+    .then().expect()
+      .statusCode(Status.FORBIDDEN.getStatusCode())
+      .contentType(ContentType.JSON)
+      .body("type", equalTo(AuthorizationException.class.getSimpleName()))
+      .body("message", equalTo(message))
+    .when()
+      .delete(SINGLE_TASK_DELETE_SINGLE_ATTACHMENT_URL);
+  }
+
+  @Test
+  public void testCreateTaskAttachmentWithContentThrowsAuthorizationException() {
+    String message = "expected exception";
+    doThrow(new AuthorizationException(message)).when(taskServiceMock)
+        .createAttachment(any(), any(), any(), any(), any(), any(InputStream.class));
+
+    given()
+      .pathParam("id", EXAMPLE_TASK_ID)
+      .multiPart("attachment-name", EXAMPLE_TASK_ATTACHMENT_NAME)
+      .multiPart("attachment-description", EXAMPLE_TASK_ATTACHMENT_DESCRIPTION)
+      .multiPart("attachment-type", EXAMPLE_TASK_ATTACHMENT_TYPE)
+      .multiPart("content", createMockByteData())
+      .header("accept", MediaType.APPLICATION_JSON)
+    .then().expect()
+      .statusCode(Status.FORBIDDEN.getStatusCode())
+      .contentType(ContentType.JSON)
+      .body("type", equalTo(AuthorizationException.class.getSimpleName()))
+      .body("message", equalTo(message))
+    .when()
+      .post(SINGLE_TASK_ADD_ATTACHMENT_URL);
+  }
+
+  @Test
+  public void testCreateTaskAttachmentWithUrlThrowsAuthorizationException() {
+    String message = "expected exception";
+    doThrow(new AuthorizationException(message)).when(taskServiceMock)
+        .createAttachment(any(), any(), any(), any(), any(), anyString());
+
+    given()
+      .pathParam("id", EXAMPLE_TASK_ID)
+      .multiPart("attachment-name", EXAMPLE_TASK_ATTACHMENT_NAME)
+      .multiPart("attachment-description", EXAMPLE_TASK_ATTACHMENT_DESCRIPTION)
+      .multiPart("attachment-type", EXAMPLE_TASK_ATTACHMENT_TYPE)
+      .multiPart("url", EXAMPLE_TASK_ATTACHMENT_URL)
+      .header("accept", MediaType.APPLICATION_JSON)
+    .then().expect()
+      .statusCode(Status.FORBIDDEN.getStatusCode())
+      .contentType(ContentType.JSON)
+      .body("type", equalTo(AuthorizationException.class.getSimpleName()))
+      .body("message", equalTo(message))
+    .when()
+      .post(SINGLE_TASK_ADD_ATTACHMENT_URL);
+  }
+
+  @Test
+  public void testGetTaskAttachmentsThrowsAuthorizationException() {
+    String message = "expected exception";
+    doThrow(new AuthorizationException(message)).when(taskServiceMock).getTaskAttachments(EXAMPLE_TASK_ID);
+
+    given()
+      .pathParam("id", EXAMPLE_TASK_ID)
+      .header("accept", MediaType.APPLICATION_JSON)
+    .then().expect()
+      .statusCode(Status.FORBIDDEN.getStatusCode())
+      .contentType(ContentType.JSON)
+      .body("type", equalTo(AuthorizationException.class.getSimpleName()))
+      .body("message", equalTo(message))
+    .when()
+      .get(SINGLE_TASK_ATTACHMENTS_URL);
+  }
+
+  @Test
+  public void testGetSingleTaskAttachmentThrowsAuthorizationException() {
+    String message = "expected exception";
+    doThrow(new AuthorizationException(message)).when(taskServiceMock)
+        .getTaskAttachment(EXAMPLE_TASK_ID, EXAMPLE_TASK_ATTACHMENT_ID);
+
+    given()
+      .pathParam("id", EXAMPLE_TASK_ID)
+      .pathParam("attachmentId", EXAMPLE_TASK_ATTACHMENT_ID)
+      .header("accept", MediaType.APPLICATION_JSON)
+    .then().expect()
+      .statusCode(Status.FORBIDDEN.getStatusCode())
+      .contentType(ContentType.JSON)
+      .body("type", equalTo(AuthorizationException.class.getSimpleName()))
+      .body("message", equalTo(message))
+    .when()
+      .get(SINGLE_TASK_SINGLE_ATTACHMENT_URL);
+  }
+
+  @Test
+  public void testGetSingleTaskAttachmentContentThrowsAuthorizationException() {
+    String message = "expected exception";
+    doThrow(new AuthorizationException(message)).when(taskServiceMock)
+        .getTaskAttachmentContent(EXAMPLE_TASK_ID, EXAMPLE_TASK_ATTACHMENT_ID);
+
+    given()
+      .pathParam("id", EXAMPLE_TASK_ID)
+      .pathParam("attachmentId", EXAMPLE_TASK_ATTACHMENT_ID)
+    .then().expect()
+      .statusCode(Status.FORBIDDEN.getStatusCode())
+      .body(containsString(message))
+    .when()
+      .get(SINGLE_TASK_SINGLE_ATTACHMENT_DATA_URL);
+  }
+
+  @Test
   public void testDeleteDeleteTask() {
 
     given()

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/CommandChecker.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/CommandChecker.java
@@ -312,6 +312,20 @@ public interface CommandChecker {
   void checkDeleteHistoricProcessInstance(HistoricProcessInstance instance);
 
   /**
+   * Checks if it is allowed to modify the given historic task instance, e.g. when an attachment is
+   * created, saved or deleted after the task has completed. The engine has no dedicated write
+   * permission for historic data, so this is granted by either DELETE_HISTORY on the process
+   * definition or ALL on the historic task itself.
+   */
+  void checkModifyHistoricTaskInstance(HistoricTaskInstanceEntity task);
+
+  /**
+   * Checks if it is allowed to modify the given historic process instance.
+   * Same reasoning as {@link #checkModifyHistoricTaskInstance}.
+   */
+  void checkModifyHistoricProcessInstance(HistoricProcessInstance instance);
+
+  /**
    * Checks if it is allowed to delete the given historic case instance.
    */
   void checkDeleteHistoricCaseInstance(HistoricCaseInstance instance);

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/CommandChecker.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/CommandChecker.java
@@ -292,6 +292,22 @@ public interface CommandChecker {
   void checkUpdateCaseDefinition(CaseDefinition caseDefinition);
 
   /**
+   * Checks if it is allowed to read the given historic task instance.
+   * <p>
+   * Only meaningful when {@code enableHistoricInstancePermissions} is switched on, because the
+   * per-instance authorizations this resolves against are only created while that flag is set.
+   */
+  void checkReadHistoricTaskInstance(HistoricTaskInstanceEntity task);
+
+  /**
+   * Checks if it is allowed to read the given historic process instance.
+   * <p>
+   * Only meaningful when {@code enableHistoricInstancePermissions} is switched on, because the
+   * per-instance authorizations this resolves against are only created while that flag is set.
+   */
+  void checkReadHistoricProcessInstance(HistoricProcessInstanceEntity processInstance);
+
+  /**
    * Checks if it is allowed to delete the given historic task instance.
    */
   void checkDeleteHistoricTaskInstance(HistoricTaskInstanceEntity task);

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/CommandChecker.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/CommandChecker.java
@@ -293,17 +293,11 @@ public interface CommandChecker {
 
   /**
    * Checks if it is allowed to read the given historic task instance.
-   * <p>
-   * Only meaningful when {@code enableHistoricInstancePermissions} is switched on, because the
-   * per-instance authorizations this resolves against are only created while that flag is set.
    */
   void checkReadHistoricTaskInstance(HistoricTaskInstanceEntity task);
 
   /**
    * Checks if it is allowed to read the given historic process instance.
-   * <p>
-   * Only meaningful when {@code enableHistoricInstancePermissions} is switched on, because the
-   * per-instance authorizations this resolves against are only created while that flag is set.
    */
   void checkReadHistoricProcessInstance(HistoricProcessInstanceEntity processInstance);
 

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -921,6 +921,13 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
    */
   protected boolean enableHistoricInstancePermissions = false;
 
+  /**
+   * Authorization checks on the task and process instance attachment commands are disabled by
+   * default. Enabling them is a behaviour change: callers that read or write attachments without
+   * holding a permission on the task or process instance start receiving an AuthorizationException.
+   */
+  protected boolean enforceAttachmentPermissions = false;
+
   protected boolean isUseSharedSqlSessionFactory = false;
 
   //History cleanup configuration
@@ -3447,6 +3454,15 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   public boolean isEnableHistoricInstancePermissions() {
     return enableHistoricInstancePermissions;
+  }
+
+  public ProcessEngineConfigurationImpl setEnforceAttachmentPermissions(boolean enforce) {
+    this.enforceAttachmentPermissions = enforce;
+    return this;
+  }
+
+  public boolean isEnforceAttachmentPermissions() {
+    return enforceAttachmentPermissions;
   }
 
   public Map<String, JobHandler> getJobHandlers() {

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -925,6 +925,16 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
    * Authorization checks on the task and process instance attachment commands are disabled by
    * default. Enabling them is a behaviour change: callers that read or write attachments without
    * holding a permission on the task or process instance start receiving an AuthorizationException.
+   * <p>
+   * Scope, once enabled:
+   * <ul>
+   * <li>Attachments of <i>running</i> tasks and process instances are fully checked.</li>
+   * <li>Attachments of <i>completed</i> ones are only checked on read, and only when
+   * {@link #enableHistoricInstancePermissions} is enabled as well, because the per-instance
+   * historic authorizations resolved there are only created while that flag is set.</li>
+   * <li>Update and delete of attachments belonging to completed tasks or process instances stay
+   * unchecked. The historic resources define no such permission today. See AttachmentAuthChecks.</li>
+   * </ul>
    */
   protected boolean enforceAttachmentPermissions = false;
 

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -925,16 +925,6 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
    * Authorization checks on the task and process instance attachment commands are disabled by
    * default. Enabling them is a behaviour change: callers that read or write attachments without
    * holding a permission on the task or process instance start receiving an AuthorizationException.
-   * <p>
-   * Scope, once enabled:
-   * <ul>
-   * <li>Attachments of <i>running</i> tasks and process instances are fully checked.</li>
-   * <li>Attachments of <i>completed</i> ones are only checked on read, and only when
-   * {@link #enableHistoricInstancePermissions} is enabled as well, because the per-instance
-   * historic authorizations resolved there are only created while that flag is set.</li>
-   * <li>Update and delete of attachments belonging to completed tasks or process instances stay
-   * unchecked. The historic resources define no such permission today. See AttachmentAuthChecks.</li>
-   * </ul>
    */
   protected boolean enforceAttachmentPermissions = false;
 

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/auth/AuthorizationCommandChecker.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/auth/AuthorizationCommandChecker.java
@@ -610,52 +610,12 @@ public class AuthorizationCommandChecker implements CommandChecker {
 
   @Override
   public void checkReadHistoricTaskInstance(HistoricTaskInstanceEntity task) {
-    if (task == null) {
-      return;
-    }
-
-    // mirrors AuthorizationManager#configureHistoricTaskInstanceQuery: a historic read is granted by
-    // either the coarse READ_HISTORY on the process definition or the fine grained per-instance
-    // permission. The latter only exists while enableHistoricInstancePermissions is set, so for a
-    // standalone task with that flag off neither branch can ever match and nothing is checked,
-    // matching what the historic queries return for such tasks.
-    boolean hasProcessDefinition = task.getProcessDefinitionKey() != null;
-    if (!hasProcessDefinition && !isHistoricInstancePermissionsEnabled()) {
-      return;
-    }
-
-    PermissionCheckBuilder builder = new PermissionCheckBuilder().disjunctive();
-
-    if (hasProcessDefinition) {
-      builder.atomicCheckForResourceId(PROCESS_DEFINITION, task.getProcessDefinitionKey(), READ_HISTORY);
-    }
-    builder.atomicCheckForResourceId(HISTORIC_TASK, task.getId(), HistoricTaskPermissions.READ);
-
-    getAuthorizationManager().checkAuthorization(builder.build());
+    getAuthorizationManager().checkReadHistoricTaskInstance(task);
   }
 
   @Override
   public void checkReadHistoricProcessInstance(HistoricProcessInstanceEntity processInstance) {
-    if (processInstance == null) {
-      return;
-    }
-
-    // same disjunction as above, see AuthorizationManager#configureHistoricProcessInstanceQuery
-    boolean hasProcessDefinition = processInstance.getProcessDefinitionKey() != null;
-    if (!hasProcessDefinition && !isHistoricInstancePermissionsEnabled()) {
-      return;
-    }
-
-    PermissionCheckBuilder builder = new PermissionCheckBuilder().disjunctive();
-
-    if (hasProcessDefinition) {
-      builder.atomicCheckForResourceId(PROCESS_DEFINITION, processInstance.getProcessDefinitionKey(),
-          READ_HISTORY);
-    }
-    builder.atomicCheckForResourceId(HISTORIC_PROCESS_INSTANCE, processInstance.getId(),
-        HistoricProcessInstancePermissions.READ);
-
-    getAuthorizationManager().checkAuthorization(builder.build());
+    getAuthorizationManager().checkReadHistoricProcessInstance(processInstance);
   }
 
   // delete permission ////////////////////////////////////////
@@ -676,6 +636,50 @@ public class AuthorizationCommandChecker implements CommandChecker {
   @Override
   public void checkDeleteHistoricProcessInstance(HistoricProcessInstance instance) {
     getAuthorizationManager().checkAuthorization(DELETE_HISTORY, PROCESS_DEFINITION, instance.getProcessDefinitionKey());
+  }
+
+  // modify permission /////////////////////////////////////////////////
+  //
+  // The engine has no dedicated write permission for historic data, so a manual mutation of a
+  // historic instance is granted by ALL on that very instance. Unlike DELETE_HISTORY on the process
+  // definition this stays scoped to the single instance and carries no delete semantics, which is
+  // what the attachment commands need when they create or save on a completed task or instance.
+
+  @Override
+  public void checkModifyHistoricTaskInstance(HistoricTaskInstanceEntity task) {
+    // modifying an unexisting historic task instance is silently ignored,
+    // mirroring checkDeleteHistoricTaskInstance
+    if (task == null) {
+      return;
+    }
+
+    PermissionCheckBuilder builder = new PermissionCheckBuilder().disjunctive();
+
+    if (task.getProcessDefinitionKey() != null) {
+      builder.atomicCheckForResourceId(PROCESS_DEFINITION, task.getProcessDefinitionKey(),
+          DELETE_HISTORY);
+    }
+    builder.atomicCheckForResourceId(HISTORIC_TASK, task.getId(), HistoricTaskPermissions.ALL);
+
+    getAuthorizationManager().checkAuthorization(builder.build());
+  }
+
+  @Override
+  public void checkModifyHistoricProcessInstance(HistoricProcessInstance instance) {
+    if (instance == null) {
+      return;
+    }
+
+    PermissionCheckBuilder builder = new PermissionCheckBuilder().disjunctive();
+
+    if (instance.getProcessDefinitionKey() != null) {
+      builder.atomicCheckForResourceId(PROCESS_DEFINITION, instance.getProcessDefinitionKey(),
+          DELETE_HISTORY);
+    }
+    builder.atomicCheckForResourceId(HISTORIC_PROCESS_INSTANCE, instance.getId(),
+        HistoricProcessInstancePermissions.ALL);
+
+    getAuthorizationManager().checkAuthorization(builder.build());
   }
 
   @Override
@@ -1039,10 +1043,6 @@ public class AuthorizationCommandChecker implements CommandChecker {
 
   protected ExecutionEntity findExecutionById(String processInstanceId) {
     return Context.getCommandContext().getExecutionManager().findExecutionById(processInstanceId);
-  }
-
-  protected boolean isHistoricInstancePermissionsEnabled() {
-    return Context.getProcessEngineConfiguration().isEnableHistoricInstancePermissions();
   }
 
 }

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/auth/AuthorizationCommandChecker.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/auth/AuthorizationCommandChecker.java
@@ -616,10 +616,17 @@ public class AuthorizationCommandChecker implements CommandChecker {
 
     // mirrors AuthorizationManager#configureHistoricTaskInstanceQuery: a historic read is granted by
     // either the coarse READ_HISTORY on the process definition or the fine grained per-instance
-    // permission. The latter only exists while enableHistoricInstancePermissions is set.
+    // permission. The latter only exists while enableHistoricInstancePermissions is set, so for a
+    // standalone task with that flag off neither branch can ever match and nothing is checked,
+    // matching what the historic queries return for such tasks.
+    boolean hasProcessDefinition = task.getProcessDefinitionKey() != null;
+    if (!hasProcessDefinition && !isHistoricInstancePermissionsEnabled()) {
+      return;
+    }
+
     PermissionCheckBuilder builder = new PermissionCheckBuilder().disjunctive();
 
-    if (task.getProcessDefinitionKey() != null) {
+    if (hasProcessDefinition) {
       builder.atomicCheckForResourceId(PROCESS_DEFINITION, task.getProcessDefinitionKey(), READ_HISTORY);
     }
     builder.atomicCheckForResourceId(HISTORIC_TASK, task.getId(), HistoricTaskPermissions.READ);
@@ -634,9 +641,14 @@ public class AuthorizationCommandChecker implements CommandChecker {
     }
 
     // same disjunction as above, see AuthorizationManager#configureHistoricProcessInstanceQuery
+    boolean hasProcessDefinition = processInstance.getProcessDefinitionKey() != null;
+    if (!hasProcessDefinition && !isHistoricInstancePermissionsEnabled()) {
+      return;
+    }
+
     PermissionCheckBuilder builder = new PermissionCheckBuilder().disjunctive();
 
-    if (processInstance.getProcessDefinitionKey() != null) {
+    if (hasProcessDefinition) {
       builder.atomicCheckForResourceId(PROCESS_DEFINITION, processInstance.getProcessDefinitionKey(),
           READ_HISTORY);
     }
@@ -1027,6 +1039,10 @@ public class AuthorizationCommandChecker implements CommandChecker {
 
   protected ExecutionEntity findExecutionById(String processInstanceId) {
     return Context.getCommandContext().getExecutionManager().findExecutionById(processInstanceId);
+  }
+
+  protected boolean isHistoricInstancePermissionsEnabled() {
+    return Context.getProcessEngineConfiguration().isEnableHistoricInstancePermissions();
   }
 
 }

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/auth/AuthorizationCommandChecker.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/auth/AuthorizationCommandChecker.java
@@ -35,10 +35,14 @@ import static org.cibseven.bpm.engine.authorization.Resources.BATCH;
 import static org.cibseven.bpm.engine.authorization.Resources.DECISION_DEFINITION;
 import static org.cibseven.bpm.engine.authorization.Resources.DECISION_REQUIREMENTS_DEFINITION;
 import static org.cibseven.bpm.engine.authorization.Resources.DEPLOYMENT;
+import static org.cibseven.bpm.engine.authorization.Resources.HISTORIC_PROCESS_INSTANCE;
+import static org.cibseven.bpm.engine.authorization.Resources.HISTORIC_TASK;
 import static org.cibseven.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
 import static org.cibseven.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
 import static org.cibseven.bpm.engine.authorization.Resources.TASK;
 
+import org.cibseven.bpm.engine.authorization.HistoricProcessInstancePermissions;
+import org.cibseven.bpm.engine.authorization.HistoricTaskPermissions;
 import org.cibseven.bpm.engine.authorization.Permission;
 import org.cibseven.bpm.engine.authorization.ProcessDefinitionPermissions;
 import org.cibseven.bpm.engine.authorization.ProcessInstancePermissions;
@@ -602,6 +606,21 @@ public class AuthorizationCommandChecker implements CommandChecker {
 
   @Override
   public void checkUpdateCaseDefinition(CaseDefinition caseDefinition) {
+  }
+
+  @Override
+  public void checkReadHistoricTaskInstance(HistoricTaskInstanceEntity task) {
+    if (task != null) {
+      getAuthorizationManager().checkAuthorization(HistoricTaskPermissions.READ, HISTORIC_TASK, task.getId());
+    }
+  }
+
+  @Override
+  public void checkReadHistoricProcessInstance(HistoricProcessInstanceEntity processInstance) {
+    if (processInstance != null) {
+      getAuthorizationManager().checkAuthorization(HistoricProcessInstancePermissions.READ,
+          HISTORIC_PROCESS_INSTANCE, processInstance.getId());
+    }
   }
 
   // delete permission ////////////////////////////////////////

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/auth/AuthorizationCommandChecker.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/auth/AuthorizationCommandChecker.java
@@ -610,17 +610,40 @@ public class AuthorizationCommandChecker implements CommandChecker {
 
   @Override
   public void checkReadHistoricTaskInstance(HistoricTaskInstanceEntity task) {
-    if (task != null) {
-      getAuthorizationManager().checkAuthorization(HistoricTaskPermissions.READ, HISTORIC_TASK, task.getId());
+    if (task == null) {
+      return;
     }
+
+    // mirrors AuthorizationManager#configureHistoricTaskInstanceQuery: a historic read is granted by
+    // either the coarse READ_HISTORY on the process definition or the fine grained per-instance
+    // permission. The latter only exists while enableHistoricInstancePermissions is set.
+    PermissionCheckBuilder builder = new PermissionCheckBuilder().disjunctive();
+
+    if (task.getProcessDefinitionKey() != null) {
+      builder.atomicCheckForResourceId(PROCESS_DEFINITION, task.getProcessDefinitionKey(), READ_HISTORY);
+    }
+    builder.atomicCheckForResourceId(HISTORIC_TASK, task.getId(), HistoricTaskPermissions.READ);
+
+    getAuthorizationManager().checkAuthorization(builder.build());
   }
 
   @Override
   public void checkReadHistoricProcessInstance(HistoricProcessInstanceEntity processInstance) {
-    if (processInstance != null) {
-      getAuthorizationManager().checkAuthorization(HistoricProcessInstancePermissions.READ,
-          HISTORIC_PROCESS_INSTANCE, processInstance.getId());
+    if (processInstance == null) {
+      return;
     }
+
+    // same disjunction as above, see AuthorizationManager#configureHistoricProcessInstanceQuery
+    PermissionCheckBuilder builder = new PermissionCheckBuilder().disjunctive();
+
+    if (processInstance.getProcessDefinitionKey() != null) {
+      builder.atomicCheckForResourceId(PROCESS_DEFINITION, processInstance.getProcessDefinitionKey(),
+          READ_HISTORY);
+    }
+    builder.atomicCheckForResourceId(HISTORIC_PROCESS_INSTANCE, processInstance.getId(),
+        HistoricProcessInstancePermissions.READ);
+
+    getAuthorizationManager().checkAuthorization(builder.build());
   }
 
   // delete permission ////////////////////////////////////////

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/multitenancy/TenantCommandChecker.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/multitenancy/TenantCommandChecker.java
@@ -437,6 +437,20 @@ public class TenantCommandChecker implements CommandChecker {
   }
 
   @Override
+  public void checkModifyHistoricTaskInstance(HistoricTaskInstanceEntity task) {
+    if (task != null && !getTenantManager().isAuthenticatedTenant(task.getTenantId())) {
+      throw LOG.exceptionCommandWithUnauthorizedTenant("modify the historic task instance '" + task.getId() + "'");
+    }
+  }
+
+  @Override
+  public void checkModifyHistoricProcessInstance(HistoricProcessInstance instance) {
+    if (instance != null && !getTenantManager().isAuthenticatedTenant(instance.getTenantId())) {
+      throw LOG.exceptionCommandWithUnauthorizedTenant("modify the historic process instance '" + instance.getId() + "'");
+    }
+  }
+
+  @Override
   public void checkDeleteHistoricCaseInstance(HistoricCaseInstance instance) {
     if (instance != null && !getTenantManager().isAuthenticatedTenant(instance.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("delete the historic case instance '"+ instance.getId() + "'");

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/multitenancy/TenantCommandChecker.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cfg/multitenancy/TenantCommandChecker.java
@@ -408,6 +408,21 @@ public class TenantCommandChecker implements CommandChecker {
   }
 
   @Override
+  public void checkReadHistoricTaskInstance(HistoricTaskInstanceEntity task) {
+    if (task != null && !getTenantManager().isAuthenticatedTenant(task.getTenantId())) {
+      throw LOG.exceptionCommandWithUnauthorizedTenant("read the historic task instance '" + task.getId() + "'");
+    }
+  }
+
+  @Override
+  public void checkReadHistoricProcessInstance(HistoricProcessInstanceEntity processInstance) {
+    if (processInstance != null && !getTenantManager().isAuthenticatedTenant(processInstance.getTenantId())) {
+      throw LOG.exceptionCommandWithUnauthorizedTenant(
+          "read the historic process instance '" + processInstance.getId() + "'");
+    }
+  }
+
+  @Override
   public void checkDeleteHistoricTaskInstance(HistoricTaskInstanceEntity task) {
     if (task != null && !getTenantManager().isAuthenticatedTenant(task.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("delete the historic task instance '"+ task.getId() + "'");

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/AttachmentAuthChecks.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/AttachmentAuthChecks.java
@@ -23,6 +23,8 @@ import org.cibseven.bpm.engine.impl.cfg.CommandChecker;
 import org.cibseven.bpm.engine.impl.interceptor.CommandContext;
 import org.cibseven.bpm.engine.impl.persistence.entity.AttachmentEntity;
 import org.cibseven.bpm.engine.impl.persistence.entity.ExecutionEntity;
+import org.cibseven.bpm.engine.impl.persistence.entity.HistoricProcessInstanceEntity;
+import org.cibseven.bpm.engine.impl.persistence.entity.HistoricTaskInstanceEntity;
 import org.cibseven.bpm.engine.impl.persistence.entity.TaskEntity;
 
 /**
@@ -33,10 +35,25 @@ import org.cibseven.bpm.engine.impl.persistence.entity.TaskEntity;
  * which is disabled by default. While disabled the commands behave exactly as before CIB7-1752,
  * including the tenant checks, and no additional entity is resolved.
  * <p>
- * The {@code ...IfExists} methods skip the check when the runtime entity is gone, which is the
- * normal state for completed tasks and process instances. Their attachments survive in
- * ACT_HI_ATTACHMENT and stay readable without a permission. Closing that would require a history
- * check, which CommandChecker does not offer today. See CIB7-1752.
+ * The {@code ...IfExists} methods resolve the runtime entity first. When it is gone, which is the
+ * normal state for completed tasks and process instances whose attachments survive in
+ * ACT_HI_ATTACHMENT, the behaviour differs per operation:
+ * <ul>
+ * <li><b>Read</b> falls back to the historic instance via
+ * {@link CommandChecker#checkReadHistoricTaskInstance} and
+ * {@link CommandChecker#checkReadHistoricProcessInstance}. That fallback additionally requires
+ * {@code enableHistoricInstancePermissions}, because the per-instance HISTORIC_TASK and
+ * HISTORIC_PROCESS_INSTANCE authorizations it resolves against are only created while that flag is
+ * set. With the flag off, historic reads stay unchecked.</li>
+ * <li><b>Update and delete</b> are <b>not</b> checked once the runtime entity is gone. There is no
+ * historic counterpart to check against: {@code HistoricTaskPermissions} and
+ * {@code HistoricProcessInstancePermissions} only define READ. Attachments of completed tasks and
+ * process instances therefore remain updatable and deletable without a permission, which is the
+ * original CIB7-1752 exposure narrowed to historic data. Closing it needs a product decision, since
+ * the options are either a coarse DELETE_HISTORY check on the process definition (which does
+ * nothing at all for standalone tasks, they carry no process definition key) or new permission
+ * values on the historic resources.</li>
+ * </ul>
  */
 final class AttachmentAuthChecks {
 
@@ -50,6 +67,8 @@ final class AttachmentAuthChecks {
     TaskEntity task = findTask(taskId, commandContext);
     if (task != null) {
       forEachChecker(commandContext, checker -> checker.checkReadTask(task));
+    } else {
+      checkReadHistoricTask(taskId, commandContext);
     }
   }
 
@@ -70,6 +89,8 @@ final class AttachmentAuthChecks {
     ExecutionEntity processInstance = findProcessInstance(processInstanceId, commandContext);
     if (processInstance != null) {
       forEachChecker(commandContext, checker -> checker.checkReadProcessInstance(processInstance));
+    } else {
+      checkReadHistoricProcessInstance(processInstanceId, commandContext);
     }
   }
 
@@ -114,6 +135,41 @@ final class AttachmentAuthChecks {
   }
 
   /**
+   * Read fallback for a task that is no longer in the runtime tables. Requires
+   * {@code enableHistoricInstancePermissions}: the per-instance HISTORIC_TASK authorizations this
+   * resolves against are only created while that flag is set, so checking without it would deny
+   * every caller instead of the unauthorized ones.
+   */
+  private static void checkReadHistoricTask(String taskId, CommandContext commandContext) {
+    if (isBlank(taskId) || !isHistoricEnforced(commandContext)) {
+      return;
+    }
+    HistoricTaskInstanceEntity historicTask = commandContext
+        .getHistoricTaskInstanceManager()
+        .findHistoricTaskInstanceById(taskId);
+    if (historicTask != null) {
+      forEachChecker(commandContext, checker -> checker.checkReadHistoricTaskInstance(historicTask));
+    }
+  }
+
+  /**
+   * Read fallback for a process instance that is no longer in the runtime tables. Same
+   * {@code enableHistoricInstancePermissions} requirement as {@link #checkReadHistoricTask}.
+   */
+  private static void checkReadHistoricProcessInstance(String processInstanceId, CommandContext commandContext) {
+    if (processInstanceId == null || !isHistoricEnforced(commandContext)) {
+      return;
+    }
+    HistoricProcessInstanceEntity historicProcessInstance = commandContext
+        .getHistoricProcessInstanceManager()
+        .findHistoricProcessInstance(processInstanceId);
+    if (historicProcessInstance != null) {
+      forEachChecker(commandContext,
+          checker -> checker.checkReadHistoricProcessInstance(historicProcessInstance));
+    }
+  }
+
+  /**
    * TaskManager#findTaskById rejects a null id, hence the guard.
    */
   private static TaskEntity findTask(String taskId, CommandContext commandContext) {
@@ -137,5 +193,9 @@ final class AttachmentAuthChecks {
 
   private static boolean isEnforced(CommandContext commandContext) {
     return commandContext.getProcessEngineConfiguration().isEnforceAttachmentPermissions();
+  }
+
+  private static boolean isHistoricEnforced(CommandContext commandContext) {
+    return commandContext.getProcessEngineConfiguration().isEnableHistoricInstancePermissions();
   }
 }

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/AttachmentAuthChecks.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/AttachmentAuthChecks.java
@@ -35,12 +35,8 @@ import org.cibseven.bpm.engine.impl.persistence.entity.TaskEntity;
  * The {@code ...IfExists} methods resolve the runtime entity first. Once it is gone, which is the
  * normal state for completed tasks and process instances, they fall back to the historic instance:
  * reads resolve READ_HISTORY on the process definition or the per-instance historic permission,
- * writes resolve DELETE_HISTORY on the process definition, the only permission the engine offers
- * for mutating historic data.
- * <p>
- * One gap remains: a standalone task carries no process definition key, and
- * {@code checkDeleteHistoricTaskInstance} passes silently in that case, so writes to its
- * attachments stay unchecked once it completed. See CIB7-1752.
+ * writes resolve DELETE_HISTORY on the process definition or ALL on the historic instance, since
+ * the engine offers no dedicated write permission for historic data.
  */
 final class AttachmentAuthChecks {
 
@@ -67,7 +63,7 @@ final class AttachmentAuthChecks {
     if (task != null) {
       forEachChecker(commandContext, checker -> checker.checkTaskWork(task));
     } else {
-      checkDeleteHistoricTask(taskId, commandContext);
+      checkModifyHistoricTask(taskId, commandContext);
     }
   }
 
@@ -91,7 +87,7 @@ final class AttachmentAuthChecks {
     if (processInstance != null) {
       forEachChecker(commandContext, checker -> checker.checkUpdateProcessInstance(processInstance));
     } else {
-      checkDeleteHistoricProcessInstance(processInstanceId, commandContext);
+      checkModifyHistoricProcessInstance(processInstanceId, commandContext);
     }
   }
 
@@ -157,9 +153,12 @@ final class AttachmentAuthChecks {
   }
 
   /**
-   * Delete fallback for a task that is no longer in the runtime tables.
+   * Write fallback for a task that is no longer in the runtime tables. The engine has no dedicated
+   * write permission for historic data, so CommandChecker#checkModifyHistoricTaskInstance accepts
+   * either DELETE_HISTORY on the process definition or ALL on the historic task, whether the caller
+   * is creating, saving or deleting an attachment.
    */
-  private static void checkDeleteHistoricTask(String taskId, CommandContext commandContext) {
+  private static void checkModifyHistoricTask(String taskId, CommandContext commandContext) {
     if (isBlank(taskId)) {
       return;
     }
@@ -167,15 +166,15 @@ final class AttachmentAuthChecks {
             .getHistoricTaskInstanceManager()
             .findHistoricTaskInstanceById(taskId);
     if (historicTask != null) {
-      forEachChecker(commandContext, checker -> checker.checkDeleteHistoricTaskInstance(historicTask));
+      forEachChecker(commandContext, checker -> checker.checkModifyHistoricTaskInstance(historicTask));
     }
   }
 
   /**
-   * Write fallback for a process instance that is no longer in the runtime tables. DELETE_HISTORY on
-   * the process definition is the only permission the engine offers for mutating historic data.
+   * Write fallback for a process instance that is no longer in the runtime tables. Same reasoning
+   * as {@link #checkModifyHistoricTask}.
    */
-  private static void checkDeleteHistoricProcessInstance(String processInstanceId, CommandContext commandContext) {
+  private static void checkModifyHistoricProcessInstance(String processInstanceId, CommandContext commandContext) {
     if (isBlank(processInstanceId)) {
       return;
     }
@@ -184,7 +183,7 @@ final class AttachmentAuthChecks {
         .findHistoricProcessInstance(processInstanceId);
     if (historicProcessInstance != null) {
       forEachChecker(commandContext,
-          checker -> checker.checkDeleteHistoricProcessInstance(historicProcessInstance));
+          checker -> checker.checkModifyHistoricProcessInstance(historicProcessInstance));
     }
   }
 

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/AttachmentAuthChecks.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/AttachmentAuthChecks.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cibseven.bpm.engine.impl.cmd;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import org.cibseven.bpm.engine.impl.cfg.CommandChecker;
+import org.cibseven.bpm.engine.impl.interceptor.CommandContext;
+import org.cibseven.bpm.engine.impl.persistence.entity.AttachmentEntity;
+import org.cibseven.bpm.engine.impl.persistence.entity.ExecutionEntity;
+import org.cibseven.bpm.engine.impl.persistence.entity.TaskEntity;
+
+/**
+ * Authorization checks for the attachment commands.
+ * <p>
+ * All checks are gated by
+ * {@link org.cibseven.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl#isEnforceAttachmentPermissions()},
+ * which is disabled by default. While disabled the commands behave exactly as before CIB7-1752,
+ * including the tenant checks, and no additional entity is resolved.
+ * <p>
+ * The {@code ...IfExists} methods skip the check when the runtime entity is gone, which is the
+ * normal state for completed tasks and process instances. Their attachments survive in
+ * ACT_HI_ATTACHMENT and stay readable without a permission. Closing that would require a history
+ * check, which CommandChecker does not offer today. See CIB7-1752.
+ */
+final class AttachmentAuthChecks {
+
+  private AttachmentAuthChecks() {
+  }
+
+  static void checkReadTaskIfExists(String taskId, CommandContext commandContext) {
+    if (!isEnforced(commandContext)) {
+      return;
+    }
+    TaskEntity task = findTask(taskId, commandContext);
+    if (task != null) {
+      forEachChecker(commandContext, checker -> checker.checkReadTask(task));
+    }
+  }
+
+  static void checkTaskWorkIfExists(String taskId, CommandContext commandContext) {
+    if (!isEnforced(commandContext)) {
+      return;
+    }
+    TaskEntity task = findTask(taskId, commandContext);
+    if (task != null) {
+      forEachChecker(commandContext, checker -> checker.checkTaskWork(task));
+    }
+  }
+
+  static void checkReadProcessInstanceIfExists(String processInstanceId, CommandContext commandContext) {
+    if (!isEnforced(commandContext)) {
+      return;
+    }
+    ExecutionEntity processInstance = findProcessInstance(processInstanceId, commandContext);
+    if (processInstance != null) {
+      forEachChecker(commandContext, checker -> checker.checkReadProcessInstance(processInstance));
+    }
+  }
+
+  static void checkUpdateProcessInstanceIfExists(String processInstanceId, CommandContext commandContext) {
+    if (!isEnforced(commandContext)) {
+      return;
+    }
+    ExecutionEntity processInstance = findProcessInstance(processInstanceId, commandContext);
+    if (processInstance != null) {
+      forEachChecker(commandContext, checker -> checker.checkUpdateProcessInstance(processInstance));
+    }
+  }
+
+  /**
+   * For commands whose only input is the attachment id.
+   */
+  static void checkReadAttachment(AttachmentEntity attachment, CommandContext commandContext) {
+    checkAttachment(attachment, AttachmentAuthChecks::checkReadTaskIfExists,
+        AttachmentAuthChecks::checkReadProcessInstanceIfExists, commandContext);
+  }
+
+  static void checkUpdateAttachment(AttachmentEntity attachment, CommandContext commandContext) {
+    checkAttachment(attachment, AttachmentAuthChecks::checkTaskWorkIfExists,
+        AttachmentAuthChecks::checkUpdateProcessInstanceIfExists, commandContext);
+  }
+
+  private static void checkAttachment(AttachmentEntity attachment,
+                                      BiConsumer<String, CommandContext> taskCheck,
+                                      BiConsumer<String, CommandContext> processInstanceCheck,
+                                      CommandContext commandContext) {
+    // tolerate a missing attachment so that the callers keep their existing behaviour for an
+    // unknown attachment id instead of failing here
+    if (attachment == null) {
+      return;
+    }
+    // an attachment may carry a task id, a process instance id or both; the task is the finer resource
+    if (!isBlank(attachment.getTaskId())) {
+      taskCheck.accept(attachment.getTaskId(), commandContext);
+    } else if (attachment.getProcessInstanceId() != null) {
+      processInstanceCheck.accept(attachment.getProcessInstanceId(), commandContext);
+    }
+  }
+
+  /**
+   * TaskManager#findTaskById rejects a null id, hence the guard.
+   */
+  private static TaskEntity findTask(String taskId, CommandContext commandContext) {
+    return isBlank(taskId) ? null : commandContext.getTaskManager().findTaskById(taskId);
+  }
+
+  private static ExecutionEntity findProcessInstance(String processInstanceId, CommandContext commandContext) {
+    return processInstanceId == null ? null
+        : commandContext.getExecutionManager().findExecutionById(processInstanceId);
+  }
+
+  private static void forEachChecker(CommandContext commandContext, Consumer<CommandChecker> action) {
+    for (CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {
+      action.accept(checker);
+    }
+  }
+
+  private static boolean isBlank(String value) {
+    return value == null || value.isBlank();
+  }
+
+  private static boolean isEnforced(CommandContext commandContext) {
+    return commandContext.getProcessEngineConfiguration().isEnforceAttachmentPermissions();
+  }
+}

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/AttachmentAuthChecks.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/AttachmentAuthChecks.java
@@ -28,32 +28,14 @@ import org.cibseven.bpm.engine.impl.persistence.entity.HistoricTaskInstanceEntit
 import org.cibseven.bpm.engine.impl.persistence.entity.TaskEntity;
 
 /**
- * Authorization checks for the attachment commands.
- * <p>
- * All checks are gated by
+ * Authorization checks for the attachment commands, gated by
  * {@link org.cibseven.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl#isEnforceAttachmentPermissions()},
- * which is disabled by default. While disabled the commands behave exactly as before CIB7-1752,
- * including the tenant checks, and no additional entity is resolved.
+ * which is disabled by default.
  * <p>
- * The {@code ...IfExists} methods resolve the runtime entity first. When it is gone, which is the
- * normal state for completed tasks and process instances whose attachments survive in
- * ACT_HI_ATTACHMENT, the behaviour differs per operation:
- * <ul>
- * <li><b>Read</b> falls back to the historic instance via
- * {@link CommandChecker#checkReadHistoricTaskInstance} and
- * {@link CommandChecker#checkReadHistoricProcessInstance}. That fallback additionally requires
- * {@code enableHistoricInstancePermissions}, because the per-instance HISTORIC_TASK and
- * HISTORIC_PROCESS_INSTANCE authorizations it resolves against are only created while that flag is
- * set. With the flag off, historic reads stay unchecked.</li>
- * <li><b>Update and delete</b> are <b>not</b> checked once the runtime entity is gone. There is no
- * historic counterpart to check against: {@code HistoricTaskPermissions} and
- * {@code HistoricProcessInstancePermissions} only define READ. Attachments of completed tasks and
- * process instances therefore remain updatable and deletable without a permission, which is the
- * original CIB7-1752 exposure narrowed to historic data. Closing it needs a product decision, since
- * the options are either a coarse DELETE_HISTORY check on the process definition (which does
- * nothing at all for standalone tasks, they carry no process definition key) or new permission
- * values on the historic resources.</li>
- * </ul>
+ * The {@code ...IfExists} methods resolve the runtime entity first. Once it is gone, which is the
+ * normal state for completed tasks and process instances, reads fall back to the historic instance
+ * check. Update and delete stay unchecked in that case: the historic resources only define READ,
+ * so there is nothing to authorize against. That remainder of CIB7-1752 needs a product decision.
  */
 final class AttachmentAuthChecks {
 
@@ -135,13 +117,10 @@ final class AttachmentAuthChecks {
   }
 
   /**
-   * Read fallback for a task that is no longer in the runtime tables. Requires
-   * {@code enableHistoricInstancePermissions}: the per-instance HISTORIC_TASK authorizations this
-   * resolves against are only created while that flag is set, so checking without it would deny
-   * every caller instead of the unauthorized ones.
+   * Read fallback for a task that is no longer in the runtime tables.
    */
   private static void checkReadHistoricTask(String taskId, CommandContext commandContext) {
-    if (isBlank(taskId) || !isHistoricEnforced(commandContext)) {
+    if (isBlank(taskId)) {
       return;
     }
     HistoricTaskInstanceEntity historicTask = commandContext
@@ -153,11 +132,10 @@ final class AttachmentAuthChecks {
   }
 
   /**
-   * Read fallback for a process instance that is no longer in the runtime tables. Same
-   * {@code enableHistoricInstancePermissions} requirement as {@link #checkReadHistoricTask}.
+   * Read fallback for a process instance that is no longer in the runtime tables.
    */
   private static void checkReadHistoricProcessInstance(String processInstanceId, CommandContext commandContext) {
-    if (processInstanceId == null || !isHistoricEnforced(commandContext)) {
+    if (processInstanceId == null) {
       return;
     }
     HistoricProcessInstanceEntity historicProcessInstance = commandContext
@@ -193,9 +171,5 @@ final class AttachmentAuthChecks {
 
   private static boolean isEnforced(CommandContext commandContext) {
     return commandContext.getProcessEngineConfiguration().isEnforceAttachmentPermissions();
-  }
-
-  private static boolean isHistoricEnforced(CommandContext commandContext) {
-    return commandContext.getProcessEngineConfiguration().isEnableHistoricInstancePermissions();
   }
 }

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/AttachmentAuthChecks.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/AttachmentAuthChecks.java
@@ -33,9 +33,14 @@ import org.cibseven.bpm.engine.impl.persistence.entity.TaskEntity;
  * which is disabled by default.
  * <p>
  * The {@code ...IfExists} methods resolve the runtime entity first. Once it is gone, which is the
- * normal state for completed tasks and process instances, reads fall back to the historic instance
- * check. Update and delete stay unchecked in that case: the historic resources only define READ,
- * so there is nothing to authorize against. That remainder of CIB7-1752 needs a product decision.
+ * normal state for completed tasks and process instances, they fall back to the historic instance:
+ * reads resolve READ_HISTORY on the process definition or the per-instance historic permission,
+ * writes resolve DELETE_HISTORY on the process definition, the only permission the engine offers
+ * for mutating historic data.
+ * <p>
+ * One gap remains: a standalone task carries no process definition key, and
+ * {@code checkDeleteHistoricTaskInstance} passes silently in that case, so writes to its
+ * attachments stay unchecked once it completed. See CIB7-1752.
  */
 final class AttachmentAuthChecks {
 
@@ -54,13 +59,15 @@ final class AttachmentAuthChecks {
     }
   }
 
-  static void checkTaskWorkIfExists(String taskId, CommandContext commandContext) {
+  static void checkModifyTaskIfExists(String taskId, CommandContext commandContext) {
     if (!isEnforced(commandContext)) {
       return;
     }
     TaskEntity task = findTask(taskId, commandContext);
     if (task != null) {
       forEachChecker(commandContext, checker -> checker.checkTaskWork(task));
+    } else {
+      checkDeleteHistoricTask(taskId, commandContext);
     }
   }
 
@@ -76,13 +83,15 @@ final class AttachmentAuthChecks {
     }
   }
 
-  static void checkUpdateProcessInstanceIfExists(String processInstanceId, CommandContext commandContext) {
+  static void checkModifyProcessInstanceIfExists(String processInstanceId, CommandContext commandContext) {
     if (!isEnforced(commandContext)) {
       return;
     }
     ExecutionEntity processInstance = findProcessInstance(processInstanceId, commandContext);
     if (processInstance != null) {
       forEachChecker(commandContext, checker -> checker.checkUpdateProcessInstance(processInstance));
+    } else {
+      checkDeleteHistoricProcessInstance(processInstanceId, commandContext);
     }
   }
 
@@ -95,8 +104,8 @@ final class AttachmentAuthChecks {
   }
 
   static void checkUpdateAttachment(AttachmentEntity attachment, CommandContext commandContext) {
-    checkAttachment(attachment, AttachmentAuthChecks::checkTaskWorkIfExists,
-        AttachmentAuthChecks::checkUpdateProcessInstanceIfExists, commandContext);
+    checkAttachment(attachment, AttachmentAuthChecks::checkModifyTaskIfExists,
+        AttachmentAuthChecks::checkModifyProcessInstanceIfExists, commandContext);
   }
 
   private static void checkAttachment(AttachmentEntity attachment,
@@ -144,6 +153,38 @@ final class AttachmentAuthChecks {
     if (historicProcessInstance != null) {
       forEachChecker(commandContext,
           checker -> checker.checkReadHistoricProcessInstance(historicProcessInstance));
+    }
+  }
+
+  /**
+   * Delete fallback for a task that is no longer in the runtime tables.
+   */
+  private static void checkDeleteHistoricTask(String taskId, CommandContext commandContext) {
+    if (isBlank(taskId)) {
+      return;
+    }
+    HistoricTaskInstanceEntity historicTask = commandContext
+            .getHistoricTaskInstanceManager()
+            .findHistoricTaskInstanceById(taskId);
+    if (historicTask != null) {
+      forEachChecker(commandContext, checker -> checker.checkDeleteHistoricTaskInstance(historicTask));
+    }
+  }
+
+  /**
+   * Write fallback for a process instance that is no longer in the runtime tables. DELETE_HISTORY on
+   * the process definition is the only permission the engine offers for mutating historic data.
+   */
+  private static void checkDeleteHistoricProcessInstance(String processInstanceId, CommandContext commandContext) {
+    if (isBlank(processInstanceId)) {
+      return;
+    }
+    HistoricProcessInstanceEntity historicProcessInstance = commandContext
+        .getHistoricProcessInstanceManager()
+        .findHistoricProcessInstance(processInstanceId);
+    if (historicProcessInstance != null) {
+      forEachChecker(commandContext,
+          checker -> checker.checkDeleteHistoricProcessInstance(historicProcessInstance));
     }
   }
 

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/CreateAttachmentCmd.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/CreateAttachmentCmd.java
@@ -72,10 +72,12 @@ public class CreateAttachmentCmd implements Command<Attachment> {
       task = commandContext
           .getTaskManager()
           .findTaskById(taskId);
+      AttachmentAuthChecks.checkTaskWorkIfExists(taskId, commandContext);
     } else {
       ensureNotNull("taskId or processInstanceId has to be provided", this.processInstanceId);
       List<ExecutionEntity> executionsByProcessInstanceId = commandContext.getExecutionManager().findExecutionsByProcessInstanceId(processInstanceId);
       processInstance = executionsByProcessInstanceId.get(0);
+      AttachmentAuthChecks.checkUpdateProcessInstanceIfExists(processInstanceId, commandContext);
     }
 
     AttachmentEntity attachment = new AttachmentEntity();

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/CreateAttachmentCmd.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/CreateAttachmentCmd.java
@@ -72,12 +72,12 @@ public class CreateAttachmentCmd implements Command<Attachment> {
       task = commandContext
           .getTaskManager()
           .findTaskById(taskId);
-      AttachmentAuthChecks.checkTaskWorkIfExists(taskId, commandContext);
+      AttachmentAuthChecks.checkModifyTaskIfExists(taskId, commandContext);
     } else {
       ensureNotNull("taskId or processInstanceId has to be provided", this.processInstanceId);
       List<ExecutionEntity> executionsByProcessInstanceId = commandContext.getExecutionManager().findExecutionsByProcessInstanceId(processInstanceId);
       processInstance = executionsByProcessInstanceId.get(0);
-      AttachmentAuthChecks.checkUpdateProcessInstanceIfExists(processInstanceId, commandContext);
+      AttachmentAuthChecks.checkModifyProcessInstanceIfExists(processInstanceId, commandContext);
     }
 
     AttachmentEntity attachment = new AttachmentEntity();

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/DeleteAttachmentCmd.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/DeleteAttachmentCmd.java
@@ -62,6 +62,8 @@ public class DeleteAttachmentCmd implements Command<Object>, Serializable {
       ensureNotNull("No attachment exists with attachmentId '" + attachmentId + "'.", "attachment", attachment);
     }
 
+    AttachmentAuthChecks.checkUpdateAttachment(attachment, commandContext);
+
     commandContext
         .getDbEntityManager()
         .delete(attachment);

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/GetAttachmentCmd.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/GetAttachmentCmd.java
@@ -37,9 +37,13 @@ public class GetAttachmentCmd implements Command<Attachment>, Serializable {
   }
 
   public Attachment execute(CommandContext commandContext) {
-    return commandContext
+    AttachmentEntity attachment = commandContext
       .getDbEntityManager()
       .selectById(AttachmentEntity.class, attachmentId);
+
+    AttachmentAuthChecks.checkReadAttachment(attachment, commandContext);
+
+    return attachment;
   }
 
 }

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/GetAttachmentContentCmd.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/GetAttachmentContentCmd.java
@@ -41,6 +41,8 @@ public class GetAttachmentContentCmd implements Command<InputStream>, Serializab
   public InputStream execute(CommandContext commandContext) {
     DbEntityManager dbEntityManger = commandContext.getDbEntityManager();
     AttachmentEntity attachment = dbEntityManger.selectById(AttachmentEntity.class, attachmentId);
+
+    AttachmentAuthChecks.checkReadAttachment(attachment, commandContext);
     
     String contentId = attachment.getContentId();
     if (contentId==null) {

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/GetProcessInstanceAttachmentsCmd.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/GetProcessInstanceAttachmentsCmd.java
@@ -37,6 +37,8 @@ public class GetProcessInstanceAttachmentsCmd implements Command<List<Attachment
   }
 
   public List<Attachment> execute(CommandContext commandContext) {
+    AttachmentAuthChecks.checkReadProcessInstanceIfExists(processInstanceId, commandContext);
+
     return commandContext
       .getAttachmentManager()
       .findAttachmentsByProcessInstanceId(processInstanceId);

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/GetTaskAttachmentCmd.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/GetTaskAttachmentCmd.java
@@ -39,6 +39,8 @@ public class GetTaskAttachmentCmd implements Command<Attachment>, Serializable {
   }
 
   public Attachment execute(CommandContext commandContext) {
+    AttachmentAuthChecks.checkReadTaskIfExists(taskId, commandContext);
+
     return commandContext
       .getAttachmentManager()
       .findAttachmentByTaskIdAndAttachmentId(taskId, attachmentId);

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/GetTaskAttachmentContentCmd.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/GetTaskAttachmentContentCmd.java
@@ -42,6 +42,8 @@ public class GetTaskAttachmentContentCmd implements Command<InputStream>, Serial
   }
 
   public InputStream execute(CommandContext commandContext) {
+    AttachmentAuthChecks.checkReadTaskIfExists(taskId, commandContext);
+
     AttachmentEntity attachment = (AttachmentEntity) commandContext
         .getAttachmentManager()
         .findAttachmentByTaskIdAndAttachmentId(taskId, attachmentId);

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/GetTaskAttachmentsCmd.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/GetTaskAttachmentsCmd.java
@@ -37,6 +37,8 @@ public class GetTaskAttachmentsCmd implements Command<List<Attachment>>, Seriali
   }
 
   public List<Attachment> execute(CommandContext commandContext) {
+    AttachmentAuthChecks.checkReadTaskIfExists(taskId, commandContext);
+
     return commandContext
       .getAttachmentManager()
       .findAttachmentsByTaskId(taskId);

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/SaveAttachmentCmd.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/cmd/SaveAttachmentCmd.java
@@ -42,6 +42,8 @@ public class SaveAttachmentCmd implements Command<Object>, Serializable {
       .getDbEntityManager()
       .selectById(AttachmentEntity.class, attachment.getId());
 
+    AttachmentAuthChecks.checkUpdateAttachment(updateAttachment, commandContext);
+
     updateAttachment.setName(attachment.getName());
     updateAttachment.setDescription(attachment.getDescription());
 

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/persistence/entity/AuthorizationManager.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/persistence/entity/AuthorizationManager.java
@@ -793,6 +793,65 @@ public class AuthorizationManager extends AbstractManager {
     }
   }
 
+  // historic instance entity checks /////////////////////////////////
+  //
+  // Entity counterparts of the two queries above: the same disjunction, but resolved for one
+  // concrete id instead of a SQL column. They live next to the query configuration so that both
+  // stay in sync whenever the historic permission model changes.
+
+  public void checkReadHistoricProcessInstance(HistoricProcessInstanceEntity processInstance) {
+    if (processInstance == null) {
+      return;
+    }
+
+    // same disjunction as configureHistoricProcessInstanceQuery
+    boolean hasProcessDefinition = processInstance.getProcessDefinitionKey() != null;
+    if (!hasProcessDefinition && !isHistoricInstancePermissionsEnabled()) {
+      return;
+    }
+
+    PermissionCheckBuilder builder = new PermissionCheckBuilder().disjunctive();
+
+    if (hasProcessDefinition) {
+      builder.atomicCheckForResourceId(PROCESS_DEFINITION,
+          processInstance.getProcessDefinitionKey(), READ_HISTORY);
+    }
+    builder.atomicCheckForResourceId(HISTORIC_PROCESS_INSTANCE, processInstance.getId(),
+        HistoricProcessInstancePermissions.READ);
+
+    checkAuthorization(builder.build());
+  }
+
+  public void checkReadHistoricTaskInstance(HistoricTaskInstanceEntity task) {
+    if (task == null) {
+      return;
+    }
+
+    // same disjunction as configureHistoricTaskInstanceQuery: a historic read is granted by either
+    // the coarse READ_HISTORY on the process definition or one of the fine grained per-instance
+    // permissions. The latter only exist while enableHistoricInstancePermissions is set, so for a
+    // standalone task with that flag off neither branch can ever match and nothing is checked,
+    // matching what the historic queries return for such tasks.
+    boolean hasProcessDefinition = task.getProcessDefinitionKey() != null;
+    if (!hasProcessDefinition && !isHistoricInstancePermissionsEnabled()) {
+      return;
+    }
+
+    PermissionCheckBuilder builder = new PermissionCheckBuilder().disjunctive();
+
+    if (hasProcessDefinition) {
+      builder.atomicCheckForResourceId(PROCESS_DEFINITION, task.getProcessDefinitionKey(),
+          READ_HISTORY);
+    }
+    if (task.getProcessInstanceId() != null) {
+      builder.atomicCheckForResourceId(HISTORIC_PROCESS_INSTANCE, task.getProcessInstanceId(),
+          HistoricProcessInstancePermissions.READ);
+    }
+    builder.atomicCheckForResourceId(HISTORIC_TASK, task.getId(), HistoricTaskPermissions.READ);
+
+    checkAuthorization(builder.build());
+  }
+
   // historic variable instance query ////////////////////////////////
 
   public void configureHistoricVariableInstanceQuery(HistoricVariableInstanceQueryImpl query) {

--- a/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/AuthorizationTest.java
+++ b/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/AuthorizationTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
+import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -50,6 +51,7 @@ import org.cibseven.bpm.engine.repository.ProcessDefinition;
 import org.cibseven.bpm.engine.runtime.CaseInstance;
 import org.cibseven.bpm.engine.runtime.Job;
 import org.cibseven.bpm.engine.runtime.ProcessInstance;
+import org.cibseven.bpm.engine.task.Attachment;
 import org.cibseven.bpm.engine.task.Comment;
 import org.cibseven.bpm.engine.task.Task;
 import org.cibseven.bpm.engine.test.util.PluggableProcessEngineTest;
@@ -292,6 +294,34 @@ public abstract class AuthorizationTest extends PluggableProcessEngineTest {
 
   protected Comment createComment(String taskId, String processInstanceId, String message) {
     return runWithoutAuthorization(() -> taskService.createComment(taskId, processInstanceId, message));
+  }
+
+  protected Attachment createAttachment(String taskId, String processInstanceId) {
+    return runWithoutAuthorization(() -> taskService.createAttachment("foo", taskId, processInstanceId,
+        "aName", "aDescription", new ByteArrayInputStream("aContent".getBytes())));
+  }
+
+  protected Attachment createAttachmentWithUrl(String taskId, String processInstanceId) {
+    return runWithoutAuthorization(() -> taskService.createAttachment("foo", taskId, processInstanceId,
+        "aName", "aDescription", "http://cibseven.org"));
+  }
+
+  protected Attachment selectAttachment(final String attachmentId) {
+    return runWithoutAuthorization(() -> taskService.getAttachment(attachmentId));
+  }
+
+  protected void deleteAttachment(final String attachmentId) {
+    runWithoutAuthorization((Callable<Void>) () -> {
+      taskService.deleteAttachment(attachmentId);
+      return null;
+    });
+  }
+
+  protected void completeTask(final String taskId) {
+    runWithoutAuthorization((Callable<Void>) () -> {
+      taskService.complete(taskId);
+      return null;
+    });
   }
 
   protected void addCandidateUser(final String taskId, final String user) {

--- a/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/ProcessInstanceAttachmentAuthorizationTest.java
+++ b/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/ProcessInstanceAttachmentAuthorizationTest.java
@@ -235,6 +235,56 @@ public class ProcessInstanceAttachmentAuthorizationTest extends AuthorizationTes
     assertThat(selectAttachment(attachment.getId())).isNull();
   }
 
+  // save attachment /////////////////////////////////////////////////////////
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldNotSaveProcessInstanceAttachmentWithoutAuthorization() {
+    // given
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    Attachment attachment = createAttachment(null, processInstanceId);
+    attachment.setName("renamedByAttacker");
+
+    // when/then
+    assertThatThrownBy(() -> taskService.saveAttachment(attachment))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'UPDATE' permission on resource '" + processInstanceId + "' of type 'ProcessInstance'");
+
+    assertThat(selectAttachment(attachment.getId()).getName()).isEqualTo("aName");
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldSaveProcessInstanceAttachmentWithUpdatePermission() {
+    // given
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    Attachment attachment = createAttachment(null, processInstanceId);
+    attachment.setName("updatedName");
+    createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
+
+    // when
+    taskService.saveAttachment(attachment);
+
+    // then
+    assertThat(selectAttachment(attachment.getId()).getName()).isEqualTo("updatedName");
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldSaveProcessInstanceAttachmentWithUpdateInstancePermissionOnProcessDefinition() {
+    // given
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    Attachment attachment = createAttachment(null, processInstanceId);
+    attachment.setName("updatedName");
+    createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_INSTANCE);
+
+    // when
+    taskService.saveAttachment(attachment);
+
+    // then
+    assertThat(selectAttachment(attachment.getId()).getName()).isEqualTo("updatedName");
+  }
+
   // get attachment by id ////////////////////////////////////////////////////
 
   @Test
@@ -318,6 +368,22 @@ public class ProcessInstanceAttachmentAuthorizationTest extends AuthorizationTes
 
     // then
     assertThat(attachment).isNotNull();
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldNotCheckSaveWhenEnforcementDisabled() {
+    // given
+    processEngineConfiguration.setEnforceAttachmentPermissions(false);
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    Attachment attachment = createAttachment(null, processInstanceId);
+    attachment.setName("updatedName");
+
+    // when
+    taskService.saveAttachment(attachment);
+
+    // then - the behaviour before CIB7-1752, no permission needed at all
+    assertThat(selectAttachment(attachment.getId()).getName()).isEqualTo("updatedName");
   }
 
   @Test

--- a/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/ProcessInstanceAttachmentAuthorizationTest.java
+++ b/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/ProcessInstanceAttachmentAuthorizationTest.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cibseven.bpm.engine.test.api.authorization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.cibseven.bpm.engine.authorization.Permissions.READ;
+import static org.cibseven.bpm.engine.authorization.Permissions.READ_INSTANCE;
+import static org.cibseven.bpm.engine.authorization.Permissions.UPDATE;
+import static org.cibseven.bpm.engine.authorization.Permissions.UPDATE_INSTANCE;
+import static org.cibseven.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
+import static org.cibseven.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
+
+import java.util.List;
+
+import org.cibseven.bpm.engine.AuthorizationException;
+import org.cibseven.bpm.engine.task.Attachment;
+import org.cibseven.bpm.engine.task.Task;
+import org.cibseven.bpm.engine.test.Deployment;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Authorization of the process instance scoped attachment commands, see CIB7-1752.
+ */
+public class ProcessInstanceAttachmentAuthorizationTest extends AuthorizationTest {
+
+  protected static final String PROCESS_KEY = "oneTaskProcess";
+  protected static final String ONE_TASK_PROCESS = "org/cibseven/bpm/engine/test/api/oneTaskProcess.bpmn20.xml";
+
+  protected static final String UNKNOWN_ID = "anUnknownId";
+
+  /**
+   * The checks are off by default, so every test below has to switch them on explicitly.
+   */
+  @Before
+  public void enforceAttachmentPermissions() {
+    processEngineConfiguration.setEnforceAttachmentPermissions(true);
+  }
+
+  @After
+  public void resetAttachmentPermissions() {
+    processEngineConfiguration.setEnforceAttachmentPermissions(false);
+  }
+
+  // create attachment ///////////////////////////////////////////////////////
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldNotCreateProcessInstanceAttachmentWithoutAuthorization() {
+    // given
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+
+    // when/then
+    assertThatThrownBy(() -> taskService.createAttachment("foo", null, processInstanceId, "aName", "aDescription",
+        "http://cibseven.org"))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'UPDATE' permission on resource '" + processInstanceId + "' of type 'ProcessInstance'")
+        .hasMessageContaining("'UPDATE_INSTANCE' permission on resource 'oneTaskProcess' of type 'ProcessDefinition'");
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldCreateProcessInstanceAttachmentWithUpdatePermission() {
+    // given
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
+
+    // when
+    Attachment attachment = taskService.createAttachment("foo", null, processInstanceId, "aName", "aDescription",
+        "http://cibseven.org");
+
+    // then
+    assertThat(attachment).isNotNull();
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldCreateProcessInstanceAttachmentWithUpdateInstancePermissionOnProcessDefinition() {
+    // given
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_INSTANCE);
+
+    // when
+    Attachment attachment = taskService.createAttachment("foo", null, processInstanceId, "aName", "aDescription",
+        "http://cibseven.org");
+
+    // then
+    assertThat(attachment).isNotNull();
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldNotCreateProcessInstanceAttachmentWithReadPermissionOnly() {
+    // given
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
+
+    // when/then
+    assertThatThrownBy(() -> taskService.createAttachment("foo", null, processInstanceId, "aName", "aDescription",
+        "http://cibseven.org"))
+        .isInstanceOf(AuthorizationException.class);
+  }
+
+  // get process instance attachments /////////////////////////////////////////
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldNotGetProcessInstanceAttachmentsWithoutAuthorization() {
+    // given
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    createAttachment(null, processInstanceId);
+
+    // when/then
+    assertThatThrownBy(() -> taskService.getProcessInstanceAttachments(processInstanceId))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'READ' permission on resource '" + processInstanceId + "' of type 'ProcessInstance'")
+        .hasMessageContaining("'READ_INSTANCE' permission on resource 'oneTaskProcess' of type 'ProcessDefinition'");
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldNotGetProcessInstanceAttachmentsWithUpdatePermissionOnly() {
+    // reading requires READ, the permission that allows writing is not enough
+    // given
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    createAttachment(null, processInstanceId);
+    createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
+
+    // when/then
+    assertThatThrownBy(() -> taskService.getProcessInstanceAttachments(processInstanceId))
+        .isInstanceOf(AuthorizationException.class);
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldGetProcessInstanceAttachmentsWithReadPermission() {
+    // given
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    createAttachment(null, processInstanceId);
+    createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
+
+    // when
+    List<Attachment> attachments = taskService.getProcessInstanceAttachments(processInstanceId);
+
+    // then
+    assertThat(attachments).hasSize(1);
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldGetProcessInstanceAttachmentsWithReadInstancePermissionOnProcessDefinition() {
+    // given
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    createAttachment(null, processInstanceId);
+    createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_INSTANCE);
+
+    // when
+    List<Attachment> attachments = taskService.getProcessInstanceAttachments(processInstanceId);
+
+    // then
+    assertThat(attachments).hasSize(1);
+  }
+
+  @Test
+  public void shouldGetEmptyAttachmentsForUnknownProcessInstanceWithoutAuthorization() {
+    // no process instance can be resolved, so there is nothing to check and nothing to return
+    assertThat(taskService.getProcessInstanceAttachments(UNKNOWN_ID)).isEmpty();
+  }
+
+  @Test
+  public void shouldGetEmptyAttachmentsForNullProcessInstanceIdWithoutAuthorization() {
+    assertThat(taskService.getProcessInstanceAttachments(null)).isEmpty();
+  }
+
+  // delete attachment ///////////////////////////////////////////////////////
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldNotDeleteProcessInstanceAttachmentWithoutAuthorization() {
+    // given
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    Attachment attachment = createAttachment(null, processInstanceId);
+
+    // when/then
+    assertThatThrownBy(() -> taskService.deleteAttachment(attachment.getId()))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'UPDATE' permission on resource '" + processInstanceId + "' of type 'ProcessInstance'");
+
+    assertThat(selectAttachment(attachment.getId())).isNotNull();
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldDeleteProcessInstanceAttachmentWithUpdatePermission() {
+    // given
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    Attachment attachment = createAttachment(null, processInstanceId);
+    createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
+
+    // when
+    taskService.deleteAttachment(attachment.getId());
+
+    // then
+    assertThat(selectAttachment(attachment.getId())).isNull();
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldDeleteProcessInstanceAttachmentWithUpdateInstancePermissionOnProcessDefinition() {
+    // given
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    Attachment attachment = createAttachment(null, processInstanceId);
+    createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_INSTANCE);
+
+    // when
+    taskService.deleteAttachment(attachment.getId());
+
+    // then
+    assertThat(selectAttachment(attachment.getId())).isNull();
+  }
+
+  // get attachment by id ////////////////////////////////////////////////////
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldNotGetProcessInstanceScopedAttachmentByIdWithoutAuthorization() {
+    // given
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    Attachment attachment = createAttachment(null, processInstanceId);
+
+    // when/then
+    assertThatThrownBy(() -> taskService.getAttachment(attachment.getId()))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'READ' permission on resource '" + processInstanceId + "' of type 'ProcessInstance'");
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldGetProcessInstanceScopedAttachmentByIdWithReadPermission() {
+    // given
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    Attachment attachment = createAttachment(null, processInstanceId);
+    createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
+
+    // when/then
+    assertThat(taskService.getAttachment(attachment.getId())).isNotNull();
+  }
+
+  // get attachment content by id ////////////////////////////////////////////
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldNotGetProcessInstanceScopedAttachmentContentByIdWithoutAuthorization() {
+    // given
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    Attachment attachment = createAttachment(null, processInstanceId);
+
+    // when/then
+    assertThatThrownBy(() -> taskService.getAttachmentContent(attachment.getId()))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'READ' permission on resource '" + processInstanceId + "' of type 'ProcessInstance'");
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldGetProcessInstanceScopedAttachmentContentByIdWithReadPermission() {
+    // given
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    Attachment attachment = createAttachment(null, processInstanceId);
+    createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
+
+    // when/then
+    assertThat(taskService.getAttachmentContent(attachment.getId())).isNotNull();
+  }
+
+  // enforceAttachmentPermissions disabled /////////////////////////////////////
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldNotCheckReadsWhenEnforcementDisabled() {
+    // given
+    processEngineConfiguration.setEnforceAttachmentPermissions(false);
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    Attachment attachment = createAttachment(null, processInstanceId);
+
+    // when/then - the behaviour before CIB7-1752, no permission needed at all
+    assertThat(taskService.getProcessInstanceAttachments(processInstanceId)).hasSize(1);
+    assertThat(taskService.getAttachment(attachment.getId())).isNotNull();
+    assertThat(taskService.getAttachmentContent(attachment.getId())).isNotNull();
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldNotCheckCreateWhenEnforcementDisabled() {
+    // given
+    processEngineConfiguration.setEnforceAttachmentPermissions(false);
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+
+    // when
+    Attachment attachment = taskService.createAttachment("foo", null, processInstanceId, "aName", "aDescription",
+        "http://cibseven.org");
+
+    // then
+    assertThat(attachment).isNotNull();
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldNotCheckDeleteWhenEnforcementDisabled() {
+    // given
+    processEngineConfiguration.setEnforceAttachmentPermissions(false);
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    Attachment attachment = createAttachment(null, processInstanceId);
+
+    // when
+    taskService.deleteAttachment(attachment.getId());
+
+    // then
+    assertThat(selectAttachment(attachment.getId())).isNull();
+  }
+
+  // known limitation ////////////////////////////////////////////////////////
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldNotCheckAuthorizationForAttachmentOfCompletedProcessInstance() {
+    // known limitation of CIB7-1752: once the runtime execution is gone the attachment only lives
+    // in ACT_HI_ATTACHMENT and no CommandChecker method can authorize it
+    // given
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    Attachment attachment = createAttachment(null, processInstanceId);
+    Task task = selectSingleTask();
+    completeTask(task.getId());
+
+    // when/then
+    assertThat(taskService.getProcessInstanceAttachments(processInstanceId)).hasSize(1);
+    assertThat(taskService.getAttachment(attachment.getId())).isNotNull();
+    assertThat(taskService.getAttachmentContent(attachment.getId())).isNotNull();
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldNotCheckAuthorizationWhenDeletingAttachmentOfCompletedProcessInstance() {
+    // known limitation of CIB7-1752, see above
+    // given
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    Attachment attachment = createAttachment(null, processInstanceId);
+    Task task = selectSingleTask();
+    completeTask(task.getId());
+
+    // when
+    taskService.deleteAttachment(attachment.getId());
+
+    // then
+    assertThat(selectAttachment(attachment.getId())).isNull();
+  }
+}

--- a/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/ProcessInstanceAttachmentAuthorizationTest.java
+++ b/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/ProcessInstanceAttachmentAuthorizationTest.java
@@ -22,12 +22,14 @@ import static org.cibseven.bpm.engine.authorization.Permissions.READ;
 import static org.cibseven.bpm.engine.authorization.Permissions.READ_INSTANCE;
 import static org.cibseven.bpm.engine.authorization.Permissions.UPDATE;
 import static org.cibseven.bpm.engine.authorization.Permissions.UPDATE_INSTANCE;
+import static org.cibseven.bpm.engine.authorization.Resources.HISTORIC_PROCESS_INSTANCE;
 import static org.cibseven.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
 import static org.cibseven.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
 
 import java.util.List;
 
 import org.cibseven.bpm.engine.AuthorizationException;
+import org.cibseven.bpm.engine.authorization.HistoricProcessInstancePermissions;
 import org.cibseven.bpm.engine.task.Attachment;
 import org.cibseven.bpm.engine.task.Task;
 import org.cibseven.bpm.engine.test.Deployment;
@@ -56,6 +58,8 @@ public class ProcessInstanceAttachmentAuthorizationTest extends AuthorizationTes
   @After
   public void resetAttachmentPermissions() {
     processEngineConfiguration.setEnforceAttachmentPermissions(false);
+    // individual tests switch this on for the historic read fallback
+    processEngineConfiguration.setEnableHistoricInstancePermissions(false);
   }
 
   // create attachment ///////////////////////////////////////////////////////
@@ -405,9 +409,11 @@ public class ProcessInstanceAttachmentAuthorizationTest extends AuthorizationTes
 
   @Test
   @Deployment(resources = ONE_TASK_PROCESS)
-  public void shouldNotCheckAuthorizationForAttachmentOfCompletedProcessInstance() {
-    // known limitation of CIB7-1752: once the runtime execution is gone the attachment only lives
-    // in ACT_HI_ATTACHMENT and no CommandChecker method can authorize it
+  public void shouldNotCheckAuthorizationForAttachmentOfCompletedProcessInstanceWithoutHistoricPermissions() {
+    // once the runtime execution is gone the attachment only lives in ACT_HI_ATTACHMENT. The
+    // historic read fallback needs enableHistoricInstancePermissions, which is off here, so nothing
+    // is checked. See shouldNotReadAttachmentOfCompletedProcessInstanceWithoutHistoricReadPermission
+    // for the enabled case.
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     Attachment attachment = createAttachment(null, processInstanceId);
@@ -418,6 +424,62 @@ public class ProcessInstanceAttachmentAuthorizationTest extends AuthorizationTes
     assertThat(taskService.getProcessInstanceAttachments(processInstanceId)).hasSize(1);
     assertThat(taskService.getAttachment(attachment.getId())).isNotNull();
     assertThat(taskService.getAttachmentContent(attachment.getId())).isNotNull();
+  }
+
+  // historic read fallback //////////////////////////////////////////////////
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldNotReadAttachmentOfCompletedProcessInstanceWithoutHistoricReadPermission() {
+    // given
+    processEngineConfiguration.setEnableHistoricInstancePermissions(true);
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    Attachment attachment = createAttachment(null, processInstanceId);
+    Task task = selectSingleTask();
+    completeTask(task.getId());
+
+    // when/then
+    assertThatThrownBy(() -> taskService.getAttachment(attachment.getId()))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(
+            "'READ' permission on resource '" + processInstanceId + "' of type 'HistoricProcessInstance'");
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldReadAttachmentOfCompletedProcessInstanceWithHistoricReadPermission() {
+    // given
+    processEngineConfiguration.setEnableHistoricInstancePermissions(true);
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    Attachment attachment = createAttachment(null, processInstanceId);
+    Task task = selectSingleTask();
+    completeTask(task.getId());
+    createGrantAuthorization(HISTORIC_PROCESS_INSTANCE, processInstanceId, userId,
+        HistoricProcessInstancePermissions.READ);
+
+    // when/then
+    assertThat(taskService.getAttachment(attachment.getId())).isNotNull();
+    assertThat(taskService.getAttachmentContent(attachment.getId())).isNotNull();
+    assertThat(taskService.getProcessInstanceAttachments(processInstanceId)).hasSize(1);
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldStillNotCheckDeleteOfCompletedProcessInstanceAttachmentWithHistoricPermissions() {
+    // remaining gap of CIB7-1752: HistoricProcessInstancePermissions defines READ only, so there is
+    // nothing to check update and delete against once the runtime execution is gone.
+    // given
+    processEngineConfiguration.setEnableHistoricInstancePermissions(true);
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    Attachment attachment = createAttachment(null, processInstanceId);
+    Task task = selectSingleTask();
+    completeTask(task.getId());
+
+    // when
+    taskService.deleteAttachment(attachment.getId());
+
+    // then
+    assertThat(selectAttachment(attachment.getId())).isNull();
   }
 
   @Test

--- a/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/ProcessInstanceAttachmentAuthorizationTest.java
+++ b/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/ProcessInstanceAttachmentAuthorizationTest.java
@@ -18,6 +18,7 @@ package org.cibseven.bpm.engine.test.api.authorization;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.cibseven.bpm.engine.authorization.Permissions.DELETE_HISTORY;
 import static org.cibseven.bpm.engine.authorization.Permissions.READ;
 import static org.cibseven.bpm.engine.authorization.Permissions.READ_HISTORY;
 import static org.cibseven.bpm.engine.authorization.Permissions.READ_INSTANCE;
@@ -480,15 +481,28 @@ public class ProcessInstanceAttachmentAuthorizationTest extends AuthorizationTes
 
   @Test
   @Deployment(resources = ONE_TASK_PROCESS)
-  public void shouldStillNotCheckDeleteOfCompletedProcessInstanceAttachmentWithHistoricPermissions() {
-    // remaining gap of CIB7-1752: HistoricProcessInstancePermissions defines READ only, so there is
-    // nothing to check update and delete against once the runtime execution is gone.
+  public void shouldNotDeleteCompletedProcessInstanceAttachmentWithoutDeleteHistory() {
     // given
-    processEngineConfiguration.setEnableHistoricInstancePermissions(true);
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     Attachment attachment = createAttachment(null, processInstanceId);
     Task task = selectSingleTask();
     completeTask(task.getId());
+
+    // when/then
+    assertThatThrownBy(() -> taskService.deleteAttachment(attachment.getId()))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'DELETE_HISTORY' permission on resource '" + PROCESS_KEY + "' of type 'ProcessDefinition'");
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldDeleteCompletedProcessInstanceAttachmentWithDeleteHistory() {
+    // given
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    Attachment attachment = createAttachment(null, processInstanceId);
+    Task task = selectSingleTask();
+    completeTask(task.getId());
+    createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, DELETE_HISTORY);
 
     // when
     taskService.deleteAttachment(attachment.getId());
@@ -499,18 +513,18 @@ public class ProcessInstanceAttachmentAuthorizationTest extends AuthorizationTes
 
   @Test
   @Deployment(resources = ONE_TASK_PROCESS)
-  public void shouldNotCheckAuthorizationWhenDeletingAttachmentOfCompletedProcessInstance() {
-    // known limitation of CIB7-1752, see above
+  public void shouldNotSaveCompletedProcessInstanceAttachmentWithoutDeleteHistory() {
+    // saving mutates historic data just like deleting, so it takes the same permission
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     Attachment attachment = createAttachment(null, processInstanceId);
     Task task = selectSingleTask();
     completeTask(task.getId());
+    attachment.setName("aNewName");
 
-    // when
-    taskService.deleteAttachment(attachment.getId());
-
-    // then
-    assertThat(selectAttachment(attachment.getId())).isNull();
+    // when/then
+    assertThatThrownBy(() -> taskService.saveAttachment(attachment))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'DELETE_HISTORY' permission on resource '" + PROCESS_KEY + "' of type 'ProcessDefinition'");
   }
 }

--- a/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/ProcessInstanceAttachmentAuthorizationTest.java
+++ b/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/ProcessInstanceAttachmentAuthorizationTest.java
@@ -527,4 +527,99 @@ public class ProcessInstanceAttachmentAuthorizationTest extends AuthorizationTes
         .isInstanceOf(AuthorizationException.class)
         .hasMessageContaining("'DELETE_HISTORY' permission on resource '" + PROCESS_KEY + "' of type 'ProcessDefinition'");
   }
+
+  // historic write fallback via the per-instance permission //////////////////
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldListBothWaysInWhenWriteOfCompletedProcessInstanceAttachmentIsDenied() {
+    // the write check is disjunctive, so the exception has to name both alternatives
+    // given
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    Attachment attachment = createAttachment(null, processInstanceId);
+    Task task = selectSingleTask();
+    completeTask(task.getId());
+
+    // when/then
+    assertThatThrownBy(() -> taskService.deleteAttachment(attachment.getId()))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'DELETE_HISTORY' permission on resource '" + PROCESS_KEY + "' of type 'ProcessDefinition'")
+        .hasMessageContaining("'ALL' permission on resource '" + processInstanceId + "' of type 'HistoricProcessInstance'");
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldDeleteCompletedProcessInstanceAttachmentWithHistoricProcessInstanceAll() {
+    // ALL on the single historic instance is the delete free way in, no DELETE_HISTORY needed
+    // given
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    Attachment attachment = createAttachment(null, processInstanceId);
+    Task task = selectSingleTask();
+    completeTask(task.getId());
+    createGrantAuthorization(HISTORIC_PROCESS_INSTANCE, processInstanceId, userId,
+        HistoricProcessInstancePermissions.ALL);
+
+    // when
+    taskService.deleteAttachment(attachment.getId());
+
+    // then
+    assertThat(selectAttachment(attachment.getId())).isNull();
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldSaveCompletedProcessInstanceAttachmentWithHistoricProcessInstanceAll() {
+    // given
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    Attachment attachment = createAttachment(null, processInstanceId);
+    Task task = selectSingleTask();
+    completeTask(task.getId());
+    createGrantAuthorization(HISTORIC_PROCESS_INSTANCE, processInstanceId, userId,
+        HistoricProcessInstancePermissions.ALL);
+    attachment.setName("aNewName");
+
+    // when
+    taskService.saveAttachment(attachment);
+
+    // then
+    assertThat(selectAttachment(attachment.getId()).getName()).isEqualTo("aNewName");
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldNotWriteCompletedProcessInstanceAttachmentWithHistoricReadOnly() {
+    // READ is not enough, the write check asks for ALL
+    // given
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    Attachment attachment = createAttachment(null, processInstanceId);
+    Task task = selectSingleTask();
+    completeTask(task.getId());
+    createGrantAuthorization(HISTORIC_PROCESS_INSTANCE, processInstanceId, userId,
+        HistoricProcessInstancePermissions.READ);
+
+    // when/then
+    assertThatThrownBy(() -> taskService.deleteAttachment(attachment.getId()))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'ALL' permission on resource '" + processInstanceId + "' of type 'HistoricProcessInstance'");
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldWriteCompletedProcessInstanceAttachmentWithHistoricAllIndependentOfInstancePermissionFlag() {
+    // the direct check does not consult enableHistoricInstancePermissions, unlike the queries
+    // given
+    processEngineConfiguration.setEnableHistoricInstancePermissions(false);
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    Attachment attachment = createAttachment(null, processInstanceId);
+    Task task = selectSingleTask();
+    completeTask(task.getId());
+    createGrantAuthorization(HISTORIC_PROCESS_INSTANCE, processInstanceId, userId,
+        HistoricProcessInstancePermissions.ALL);
+
+    // when
+    taskService.deleteAttachment(attachment.getId());
+
+    // then
+    assertThat(selectAttachment(attachment.getId())).isNull();
+  }
 }

--- a/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/ProcessInstanceAttachmentAuthorizationTest.java
+++ b/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/ProcessInstanceAttachmentAuthorizationTest.java
@@ -19,6 +19,7 @@ package org.cibseven.bpm.engine.test.api.authorization;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.cibseven.bpm.engine.authorization.Permissions.READ;
+import static org.cibseven.bpm.engine.authorization.Permissions.READ_HISTORY;
 import static org.cibseven.bpm.engine.authorization.Permissions.READ_INSTANCE;
 import static org.cibseven.bpm.engine.authorization.Permissions.UPDATE;
 import static org.cibseven.bpm.engine.authorization.Permissions.UPDATE_INSTANCE;
@@ -409,16 +410,30 @@ public class ProcessInstanceAttachmentAuthorizationTest extends AuthorizationTes
 
   @Test
   @Deployment(resources = ONE_TASK_PROCESS)
-  public void shouldNotCheckAuthorizationForAttachmentOfCompletedProcessInstanceWithoutHistoricPermissions() {
-    // once the runtime execution is gone the attachment only lives in ACT_HI_ATTACHMENT. The
-    // historic read fallback needs enableHistoricInstancePermissions, which is off here, so nothing
-    // is checked. See shouldNotReadAttachmentOfCompletedProcessInstanceWithoutHistoricReadPermission
-    // for the enabled case.
+  public void shouldNotReadAttachmentOfCompletedProcessInstanceWithoutAnyHistoricPermission() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     Attachment attachment = createAttachment(null, processInstanceId);
     Task task = selectSingleTask();
     completeTask(task.getId());
+
+    // when/then
+    assertThatThrownBy(() -> taskService.getAttachment(attachment.getId()))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'READ_HISTORY' permission on resource '" + PROCESS_KEY + "' of type 'ProcessDefinition'")
+        .hasMessageContaining(
+            "'READ' permission on resource '" + processInstanceId + "' of type 'HistoricProcessInstance'");
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldReadAttachmentOfCompletedProcessInstanceWithReadHistoryOnProcessDefinition() {
+    // given
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    Attachment attachment = createAttachment(null, processInstanceId);
+    Task task = selectSingleTask();
+    completeTask(task.getId());
+    createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_HISTORY);
 
     // when/then
     assertThat(taskService.getProcessInstanceAttachments(processInstanceId)).hasSize(1);

--- a/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/TaskAttachmentAuthorizationTest.java
+++ b/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/TaskAttachmentAuthorizationTest.java
@@ -25,6 +25,7 @@ import static org.cibseven.bpm.engine.authorization.Permissions.READ_TASK;
 import static org.cibseven.bpm.engine.authorization.Permissions.TASK_WORK;
 import static org.cibseven.bpm.engine.authorization.Permissions.UPDATE;
 import static org.cibseven.bpm.engine.authorization.Permissions.UPDATE_TASK;
+import static org.cibseven.bpm.engine.authorization.Resources.HISTORIC_PROCESS_INSTANCE;
 import static org.cibseven.bpm.engine.authorization.Resources.HISTORIC_TASK;
 import static org.cibseven.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
 import static org.cibseven.bpm.engine.authorization.Resources.TASK;
@@ -33,6 +34,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 
 import org.cibseven.bpm.engine.AuthorizationException;
+import org.cibseven.bpm.engine.authorization.HistoricProcessInstancePermissions;
 import org.cibseven.bpm.engine.authorization.HistoricTaskPermissions;
 import org.cibseven.bpm.engine.task.Attachment;
 import org.cibseven.bpm.engine.task.Task;
@@ -705,6 +707,45 @@ public class TaskAttachmentAuthorizationTest extends AuthorizationTest {
 
   @Test
   @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldReadAttachmentOfCompletedTaskWithHistoricProcessInstanceReadPermission() {
+    // the read check mirrors configureHistoricTaskInstanceQuery, which also lets the permission on
+    // the owning historic process instance grant access to the task
+    // given
+    processEngineConfiguration.setEnableHistoricInstancePermissions(true);
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    Task task = selectSingleTask();
+    Attachment attachment = createAttachment(task.getId(), null);
+    completeTask(task.getId());
+    createGrantAuthorization(HISTORIC_PROCESS_INSTANCE, processInstanceId, userId,
+        HistoricProcessInstancePermissions.READ);
+
+    // when/then
+    assertThat(taskService.getAttachment(attachment.getId())).isNotNull();
+    assertThat(taskService.getAttachmentContent(attachment.getId())).isNotNull();
+    assertThat(taskService.getTaskAttachments(task.getId())).hasSize(1);
+    assertThat(taskService.getTaskAttachment(task.getId(), attachment.getId())).isNotNull();
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldListAllThreeWaysInWhenReadOfCompletedTaskAttachmentIsDenied() {
+    // given
+    processEngineConfiguration.setEnableHistoricInstancePermissions(true);
+    String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
+    Task task = selectSingleTask();
+    Attachment attachment = createAttachment(task.getId(), null);
+    completeTask(task.getId());
+
+    // when/then
+    assertThatThrownBy(() -> taskService.getAttachment(attachment.getId()))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'READ_HISTORY' permission on resource '" + PROCESS_KEY + "' of type 'ProcessDefinition'")
+        .hasMessageContaining("'READ' permission on resource '" + processInstanceId + "' of type 'HistoricProcessInstance'")
+        .hasMessageContaining("'READ' permission on resource '" + task.getId() + "' of type 'HistoricTask'");
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
   public void shouldNotDeleteCompletedTaskAttachmentWithoutDeleteHistory() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
@@ -753,20 +794,52 @@ public class TaskAttachmentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldStillNotCheckDeleteOfCompletedStandaloneTaskAttachment() {
-    // remaining gap: a standalone task carries no process definition key, and
-    // checkDeleteHistoricTaskInstance silently passes in that case. HistoricTaskPermissions defines
-    // no write permission that could take its place.
+  public void shouldNotDeleteCompletedStandaloneTaskAttachmentWithoutHistoricTaskAll() {
+    // a standalone task carries no process definition key, so DELETE_HISTORY can never match and
+    // ALL on the historic task is the only way in
     // given
     createTask(TASK_ID);
     Attachment attachment = createAttachment(TASK_ID, null);
     completeTask(TASK_ID);
+
+    // when/then
+    assertThatThrownBy(() -> taskService.deleteAttachment(attachment.getId()))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'ALL' permission on resource '" + TASK_ID + "' of type 'HistoricTask'");
+  }
+
+  @Test
+  public void shouldDeleteCompletedStandaloneTaskAttachmentWithHistoricTaskAll() {
+    // given
+    createTask(TASK_ID);
+    Attachment attachment = createAttachment(TASK_ID, null);
+    completeTask(TASK_ID);
+    createGrantAuthorization(HISTORIC_TASK, TASK_ID, userId, HistoricTaskPermissions.ALL);
 
     // when
     taskService.deleteAttachment(attachment.getId());
 
     // then
     assertThat(selectAttachment(attachment.getId())).isNull();
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldSaveCompletedTaskAttachmentWithHistoricTaskAll() {
+    // the non-delete way in: ALL on the historic task instead of DELETE_HISTORY on the definition
+    // given
+    startProcessInstanceByKey(PROCESS_KEY);
+    Task task = selectSingleTask();
+    Attachment attachment = createAttachment(task.getId(), null);
+    completeTask(task.getId());
+    createGrantAuthorization(HISTORIC_TASK, task.getId(), userId, HistoricTaskPermissions.ALL);
+    attachment.setName("aNewName");
+
+    // when
+    taskService.saveAttachment(attachment);
+
+    // then
+    assertThat(selectAttachment(attachment.getId()).getName()).isEqualTo("aNewName");
   }
 
   // enforceAttachmentPermissions disabled /////////////////////////////////////

--- a/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/TaskAttachmentAuthorizationTest.java
+++ b/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/TaskAttachmentAuthorizationTest.java
@@ -1,0 +1,631 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cibseven.bpm.engine.test.api.authorization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.cibseven.bpm.engine.authorization.Permissions.READ;
+import static org.cibseven.bpm.engine.authorization.Permissions.READ_TASK;
+import static org.cibseven.bpm.engine.authorization.Permissions.TASK_WORK;
+import static org.cibseven.bpm.engine.authorization.Permissions.UPDATE;
+import static org.cibseven.bpm.engine.authorization.Permissions.UPDATE_TASK;
+import static org.cibseven.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
+import static org.cibseven.bpm.engine.authorization.Resources.TASK;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import org.cibseven.bpm.engine.AuthorizationException;
+import org.cibseven.bpm.engine.task.Attachment;
+import org.cibseven.bpm.engine.task.Task;
+import org.cibseven.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
+import org.cibseven.bpm.engine.test.Deployment;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Authorization of the task scoped attachment commands, see CIB7-1752.
+ */
+public class TaskAttachmentAuthorizationTest extends AuthorizationTest {
+
+  protected static final String PROCESS_KEY = "oneTaskProcess";
+  protected static final String ONE_TASK_PROCESS = "org/cibseven/bpm/engine/test/api/oneTaskProcess.bpmn20.xml";
+
+  protected static final String UNKNOWN_ID = "anUnknownId";
+
+  /**
+   * The checks are off by default, so every test below has to switch them on explicitly.
+   */
+  @Before
+  public void enforceAttachmentPermissions() {
+    processEngineConfiguration.setEnforceAttachmentPermissions(true);
+  }
+
+  @After
+  public void resetAttachmentPermissions() {
+    processEngineConfiguration.setEnforceAttachmentPermissions(false);
+  }
+
+  /**
+   * Standalone tasks are not covered by the deployment cleanup, so drop them including their
+   * attachments. Tests that expect an AuthorizationException leave the attachment behind.
+   */
+  @After
+  public void deleteStandaloneTask() {
+    runWithoutAuthorization((Callable<Void>) () -> {
+      Task task = taskService.createTaskQuery().taskId(TASK_ID).singleResult();
+      if (task != null) {
+        taskService.deleteTask(TASK_ID, true);
+      }
+      return null;
+    });
+  }
+
+  // create attachment ///////////////////////////////////////////////////////
+
+  @Test
+  public void shouldNotCreateStandaloneTaskAttachmentWithoutAuthorization() {
+    // given
+    createTask(TASK_ID);
+
+    // when/then
+    assertThatThrownBy(() -> taskService.createAttachment("foo", TASK_ID, null, "aName", "aDescription",
+        "http://cibseven.org"))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'TASK_WORK' permission on resource 'myTask' of type 'Task'")
+        .hasMessageContaining("'UPDATE' permission on resource 'myTask' of type 'Task'");
+  }
+
+  @Test
+  public void shouldCreateStandaloneTaskAttachmentWithUpdatePermission() {
+    // given
+    createTask(TASK_ID);
+    createGrantAuthorization(TASK, TASK_ID, userId, UPDATE);
+
+    // when
+    Attachment attachment = taskService.createAttachment("foo", TASK_ID, null, "aName", "aDescription",
+        "http://cibseven.org");
+
+    // then
+    assertThat(attachment).isNotNull();
+  }
+
+  @Test
+  public void shouldCreateStandaloneTaskAttachmentWithTaskWorkPermission() {
+    // given
+    createTask(TASK_ID);
+    createGrantAuthorization(TASK, TASK_ID, userId, TASK_WORK);
+
+    // when
+    Attachment attachment = taskService.createAttachment("foo", TASK_ID, null, "aName", "aDescription",
+        "http://cibseven.org");
+
+    // then
+    assertThat(attachment).isNotNull();
+  }
+
+  @Test
+  public void shouldNotCreateStandaloneTaskAttachmentWithReadPermissionOnly() {
+    // given
+    createTask(TASK_ID);
+    createGrantAuthorization(TASK, TASK_ID, userId, READ);
+
+    // when/then
+    assertThatThrownBy(() -> taskService.createAttachment("foo", TASK_ID, null, "aName", "aDescription",
+        "http://cibseven.org"))
+        .isInstanceOf(AuthorizationException.class);
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldNotCreateProcessTaskAttachmentWithoutAuthorization() {
+    // given
+    startProcessInstanceByKey(PROCESS_KEY);
+    Task task = selectSingleTask();
+
+    // when/then
+    assertThatThrownBy(() -> taskService.createAttachment("foo", task.getId(), null, "aName", "aDescription",
+        "http://cibseven.org"))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'UPDATE_TASK' permission on resource 'oneTaskProcess' of type 'ProcessDefinition'");
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldCreateProcessTaskAttachmentWithUpdatePermissionOnTask() {
+    // given
+    startProcessInstanceByKey(PROCESS_KEY);
+    Task task = selectSingleTask();
+    createGrantAuthorization(TASK, task.getId(), userId, UPDATE);
+
+    // when
+    Attachment attachment = taskService.createAttachment("foo", task.getId(), null, "aName", "aDescription",
+        "http://cibseven.org");
+
+    // then
+    assertThat(attachment).isNotNull();
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldCreateProcessTaskAttachmentWithUpdateTaskPermissionOnProcessDefinition() {
+    // given
+    startProcessInstanceByKey(PROCESS_KEY);
+    Task task = selectSingleTask();
+    createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_TASK);
+
+    // when
+    Attachment attachment = taskService.createAttachment("foo", task.getId(), null, "aName", "aDescription",
+        "http://cibseven.org");
+
+    // then
+    assertThat(attachment).isNotNull();
+  }
+
+  @Test
+  public void shouldCreateAttachmentForUnknownTaskWithoutAuthorization() {
+    // documents the current behaviour: no task can be resolved, so no permission can be checked
+    // and an orphan attachment is created
+
+    // when
+    Attachment attachment = taskService.createAttachment("foo", UNKNOWN_ID, null, "aName", "aDescription",
+        "http://cibseven.org");
+
+    // then
+    assertThat(attachment).isNotNull();
+
+    deleteAttachment(attachment.getId());
+  }
+
+  // delete attachment ///////////////////////////////////////////////////////
+
+  @Test
+  public void shouldNotDeleteStandaloneTaskAttachmentWithoutAuthorization() {
+    // given
+    createTask(TASK_ID);
+    Attachment attachment = createAttachment(TASK_ID, null);
+
+    // when/then
+    assertThatThrownBy(() -> taskService.deleteAttachment(attachment.getId()))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'TASK_WORK' permission on resource 'myTask' of type 'Task'");
+
+    assertThat(selectAttachment(attachment.getId())).isNotNull();
+  }
+
+  @Test
+  public void shouldDeleteStandaloneTaskAttachmentWithUpdatePermission() {
+    // given
+    createTask(TASK_ID);
+    Attachment attachment = createAttachment(TASK_ID, null);
+    createGrantAuthorization(TASK, TASK_ID, userId, UPDATE);
+
+    // when
+    taskService.deleteAttachment(attachment.getId());
+
+    // then
+    assertThat(selectAttachment(attachment.getId())).isNull();
+  }
+
+  @Test
+  public void shouldNotDeleteStandaloneTaskAttachmentByTaskIdWithoutAuthorization() {
+    // given
+    createTask(TASK_ID);
+    Attachment attachment = createAttachment(TASK_ID, null);
+
+    // when/then
+    assertThatThrownBy(() -> taskService.deleteTaskAttachment(TASK_ID, attachment.getId()))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'TASK_WORK' permission on resource 'myTask' of type 'Task'");
+
+    assertThat(selectAttachment(attachment.getId())).isNotNull();
+  }
+
+  @Test
+  public void shouldDeleteStandaloneTaskAttachmentByTaskIdWithUpdatePermission() {
+    // given
+    createTask(TASK_ID);
+    Attachment attachment = createAttachment(TASK_ID, null);
+    createGrantAuthorization(TASK, TASK_ID, userId, UPDATE);
+
+    // when
+    taskService.deleteTaskAttachment(TASK_ID, attachment.getId());
+
+    // then
+    assertThat(selectAttachment(attachment.getId())).isNull();
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldNotDeleteProcessTaskAttachmentWithoutAuthorization() {
+    // given
+    startProcessInstanceByKey(PROCESS_KEY);
+    Task task = selectSingleTask();
+    Attachment attachment = createAttachment(task.getId(), null);
+
+    // when/then
+    assertThatThrownBy(() -> taskService.deleteAttachment(attachment.getId()))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'UPDATE_TASK' permission on resource 'oneTaskProcess' of type 'ProcessDefinition'");
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldDeleteProcessTaskAttachmentWithUpdateTaskPermissionOnProcessDefinition() {
+    // given
+    startProcessInstanceByKey(PROCESS_KEY);
+    Task task = selectSingleTask();
+    Attachment attachment = createAttachment(task.getId(), null);
+    createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_TASK);
+
+    // when
+    taskService.deleteAttachment(attachment.getId());
+
+    // then
+    assertThat(selectAttachment(attachment.getId())).isNull();
+  }
+
+  // get task attachments ////////////////////////////////////////////////////
+
+  @Test
+  public void shouldNotGetStandaloneTaskAttachmentsWithoutAuthorization() {
+    // given
+    createTask(TASK_ID);
+    createAttachment(TASK_ID, null);
+
+    // when/then
+    assertThatThrownBy(() -> taskService.getTaskAttachments(TASK_ID))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'READ' permission on resource 'myTask' of type 'Task'");
+  }
+
+  @Test
+  public void shouldNotGetStandaloneTaskAttachmentsWithUpdatePermissionOnly() {
+    // reading requires READ, the permission that allows writing is not enough
+    // given
+    createTask(TASK_ID);
+    createAttachment(TASK_ID, null);
+    createGrantAuthorization(TASK, TASK_ID, userId, UPDATE);
+
+    // when/then
+    assertThatThrownBy(() -> taskService.getTaskAttachments(TASK_ID))
+        .isInstanceOf(AuthorizationException.class);
+  }
+
+  @Test
+  public void shouldGetStandaloneTaskAttachmentsWithReadPermission() {
+    // given
+    createTask(TASK_ID);
+    createAttachment(TASK_ID, null);
+    createGrantAuthorization(TASK, TASK_ID, userId, READ);
+
+    // when
+    List<Attachment> attachments = taskService.getTaskAttachments(TASK_ID);
+
+    // then
+    assertThat(attachments).hasSize(1);
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldNotGetProcessTaskAttachmentsWithoutAuthorization() {
+    // given
+    startProcessInstanceByKey(PROCESS_KEY);
+    Task task = selectSingleTask();
+    createAttachment(task.getId(), null);
+
+    // when/then
+    assertThatThrownBy(() -> taskService.getTaskAttachments(task.getId()))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'READ_TASK' permission on resource 'oneTaskProcess' of type 'ProcessDefinition'");
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldGetProcessTaskAttachmentsWithReadTaskPermissionOnProcessDefinition() {
+    // given
+    startProcessInstanceByKey(PROCESS_KEY);
+    Task task = selectSingleTask();
+    createAttachment(task.getId(), null);
+    createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_TASK);
+
+    // when
+    List<Attachment> attachments = taskService.getTaskAttachments(task.getId());
+
+    // then
+    assertThat(attachments).hasSize(1);
+  }
+
+  @Test
+  public void shouldGetEmptyAttachmentsForUnknownTaskWithoutAuthorization() {
+    // no task can be resolved, so there is nothing to check and nothing to return
+    assertThat(taskService.getTaskAttachments(UNKNOWN_ID)).isEmpty();
+  }
+
+  @Test
+  public void shouldGetEmptyAttachmentsForNullTaskIdWithoutAuthorization() {
+    // TaskManager#findTaskById rejects a null id, the command must not resolve the task in that case
+    assertThat(taskService.getTaskAttachments(null)).isEmpty();
+  }
+
+  // get single task attachment //////////////////////////////////////////////
+
+  @Test
+  public void shouldNotGetStandaloneTaskAttachmentWithoutAuthorization() {
+    // given
+    createTask(TASK_ID);
+    Attachment attachment = createAttachment(TASK_ID, null);
+
+    // when/then
+    assertThatThrownBy(() -> taskService.getTaskAttachment(TASK_ID, attachment.getId()))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'READ' permission on resource 'myTask' of type 'Task'");
+  }
+
+  @Test
+  public void shouldGetStandaloneTaskAttachmentWithReadPermission() {
+    // given
+    createTask(TASK_ID);
+    Attachment attachment = createAttachment(TASK_ID, null);
+    createGrantAuthorization(TASK, TASK_ID, userId, READ);
+
+    // when/then
+    assertThat(taskService.getTaskAttachment(TASK_ID, attachment.getId())).isNotNull();
+  }
+
+  @Test
+  public void shouldGetNullTaskAttachmentForNullParametersWithoutAuthorization() {
+    // TaskManager#findTaskById rejects a null id, the command must not resolve the task in that case
+    assertThat(taskService.getTaskAttachment(null, null)).isNull();
+  }
+
+  @Test
+  public void shouldGetNullTaskAttachmentForUnknownAttachmentIdWithReadPermission() {
+    // given
+    createTask(TASK_ID);
+    createGrantAuthorization(TASK, TASK_ID, userId, READ);
+
+    // when/then
+    assertThat(taskService.getTaskAttachment(TASK_ID, UNKNOWN_ID)).isNull();
+  }
+
+  // get task attachment content /////////////////////////////////////////////
+
+  @Test
+  public void shouldNotGetStandaloneTaskAttachmentContentWithoutAuthorization() {
+    // given
+    createTask(TASK_ID);
+    Attachment attachment = createAttachment(TASK_ID, null);
+
+    // when/then
+    assertThatThrownBy(() -> taskService.getTaskAttachmentContent(TASK_ID, attachment.getId()))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'READ' permission on resource 'myTask' of type 'Task'");
+  }
+
+  @Test
+  public void shouldGetStandaloneTaskAttachmentContentWithReadPermission() {
+    // given
+    createTask(TASK_ID);
+    Attachment attachment = createAttachment(TASK_ID, null);
+    createGrantAuthorization(TASK, TASK_ID, userId, READ);
+
+    // when/then
+    assertThat(taskService.getTaskAttachmentContent(TASK_ID, attachment.getId())).isNotNull();
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldNotGetProcessTaskAttachmentContentWithoutAuthorization() {
+    // given
+    startProcessInstanceByKey(PROCESS_KEY);
+    Task task = selectSingleTask();
+    Attachment attachment = createAttachment(task.getId(), null);
+
+    // when/then
+    assertThatThrownBy(() -> taskService.getTaskAttachmentContent(task.getId(), attachment.getId()))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'READ_TASK' permission on resource 'oneTaskProcess' of type 'ProcessDefinition'");
+  }
+
+  @Test
+  public void shouldGetNullContentForNullParametersWithoutAuthorization() {
+    // TaskManager#findTaskById rejects a null id, the command must not resolve the task in that case
+    assertThat(taskService.getTaskAttachmentContent(null, null)).isNull();
+  }
+
+  @Test
+  public void shouldGetNullContentForUrlAttachmentWithReadPermission() {
+    // given
+    createTask(TASK_ID);
+    Attachment attachment = createAttachmentWithUrl(TASK_ID, null);
+    createGrantAuthorization(TASK, TASK_ID, userId, READ);
+
+    // when/then
+    assertThat(taskService.getTaskAttachmentContent(TASK_ID, attachment.getId())).isNull();
+  }
+
+  // get attachment by id ////////////////////////////////////////////////////
+
+  @Test
+  public void shouldNotGetTaskScopedAttachmentByIdWithoutAuthorization() {
+    // given
+    createTask(TASK_ID);
+    Attachment attachment = createAttachment(TASK_ID, null);
+
+    // when/then
+    assertThatThrownBy(() -> taskService.getAttachment(attachment.getId()))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'READ' permission on resource 'myTask' of type 'Task'");
+  }
+
+  @Test
+  public void shouldGetTaskScopedAttachmentByIdWithReadPermission() {
+    // given
+    createTask(TASK_ID);
+    Attachment attachment = createAttachment(TASK_ID, null);
+    createGrantAuthorization(TASK, TASK_ID, userId, READ);
+
+    // when/then
+    assertThat(taskService.getAttachment(attachment.getId())).isNotNull();
+  }
+
+  @Test
+  public void shouldGetNullAttachmentForUnknownAttachmentIdWithoutAuthorization() {
+    // the attachment carries the resource to check, so an unknown id cannot be checked at all
+    assertThat(taskService.getAttachment(UNKNOWN_ID)).isNull();
+  }
+
+  // get attachment content by id ////////////////////////////////////////////
+
+  @Test
+  public void shouldNotGetTaskScopedAttachmentContentByIdWithoutAuthorization() {
+    // given
+    createTask(TASK_ID);
+    Attachment attachment = createAttachment(TASK_ID, null);
+
+    // when/then
+    assertThatThrownBy(() -> taskService.getAttachmentContent(attachment.getId()))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'READ' permission on resource 'myTask' of type 'Task'");
+  }
+
+  @Test
+  public void shouldGetTaskScopedAttachmentContentByIdWithReadPermission() {
+    // given
+    createTask(TASK_ID);
+    Attachment attachment = createAttachment(TASK_ID, null);
+    createGrantAuthorization(TASK, TASK_ID, userId, READ);
+
+    // when/then
+    assertThat(taskService.getAttachmentContent(attachment.getId())).isNotNull();
+  }
+
+  // dispatch order //////////////////////////////////////////////////////////
+
+  @Test
+  public void shouldCheckTaskAndNotProcessInstanceWhenAttachmentCarriesBothIds() {
+    // an attachment may carry an arbitrary process instance id next to its task id, the task wins
+    // given
+    createTask(TASK_ID);
+    Attachment attachment = createAttachment(TASK_ID, UNKNOWN_ID);
+    createGrantAuthorization(TASK, TASK_ID, userId, READ);
+
+    // when/then
+    assertThat(taskService.getAttachment(attachment.getId())).isNotNull();
+  }
+
+  @Test
+  public void shouldRejectAttachmentCarryingBothIdsWithoutTaskPermission() {
+    // given
+    createTask(TASK_ID);
+    Attachment attachment = createAttachment(TASK_ID, UNKNOWN_ID);
+
+    // when/then
+    assertThatThrownBy(() -> taskService.getAttachment(attachment.getId()))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'READ' permission on resource 'myTask' of type 'Task'");
+  }
+
+  // known limitation ////////////////////////////////////////////////////////
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldNotCheckAuthorizationForAttachmentOfCompletedTask() {
+    // known limitation of CIB7-1752: once the runtime task is gone the attachment only lives in
+    // ACT_HI_ATTACHMENT and no CommandChecker method can authorize it
+    // given
+    startProcessInstanceByKey(PROCESS_KEY);
+    Task task = selectSingleTask();
+    Attachment attachment = createAttachment(task.getId(), null);
+    completeTask(task.getId());
+
+    // when/then
+    assertThat(taskService.getTaskAttachments(task.getId())).hasSize(1);
+    assertThat(taskService.getTaskAttachment(task.getId(), attachment.getId())).isNotNull();
+    assertThat(taskService.getAttachment(attachment.getId())).isNotNull();
+    assertThat(taskService.getAttachmentContent(attachment.getId())).isNotNull();
+  }
+
+  // enforceAttachmentPermissions disabled /////////////////////////////////////
+
+  @Test
+  public void shouldDisableAttachmentPermissionsByDefault() {
+    assertThat(new StandaloneInMemProcessEngineConfiguration().isEnforceAttachmentPermissions()).isFalse();
+  }
+
+  @Test
+  public void shouldNotCheckReadsWhenEnforcementDisabled() {
+    // given
+    processEngineConfiguration.setEnforceAttachmentPermissions(false);
+    createTask(TASK_ID);
+    Attachment attachment = createAttachment(TASK_ID, null);
+
+    // when/then - the behaviour before CIB7-1752, no permission needed at all
+    assertThat(taskService.getTaskAttachments(TASK_ID)).hasSize(1);
+    assertThat(taskService.getTaskAttachment(TASK_ID, attachment.getId())).isNotNull();
+    assertThat(taskService.getTaskAttachmentContent(TASK_ID, attachment.getId())).isNotNull();
+    assertThat(taskService.getAttachment(attachment.getId())).isNotNull();
+    assertThat(taskService.getAttachmentContent(attachment.getId())).isNotNull();
+  }
+
+  @Test
+  public void shouldNotCheckCreateWhenEnforcementDisabled() {
+    // given
+    processEngineConfiguration.setEnforceAttachmentPermissions(false);
+    createTask(TASK_ID);
+
+    // when
+    Attachment attachment = taskService.createAttachment("foo", TASK_ID, null, "aName", "aDescription",
+        "http://cibseven.org");
+
+    // then
+    assertThat(attachment).isNotNull();
+  }
+
+  @Test
+  public void shouldNotCheckDeleteWhenEnforcementDisabled() {
+    // given
+    processEngineConfiguration.setEnforceAttachmentPermissions(false);
+    createTask(TASK_ID);
+    Attachment attachment = createAttachment(TASK_ID, null);
+
+    // when
+    taskService.deleteAttachment(attachment.getId());
+
+    // then
+    assertThat(selectAttachment(attachment.getId())).isNull();
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldNotCheckAuthorizationWhenDeletingAttachmentOfCompletedTask() {
+    // known limitation of CIB7-1752, see above
+    // given
+    startProcessInstanceByKey(PROCESS_KEY);
+    Task task = selectSingleTask();
+    Attachment attachment = createAttachment(task.getId(), null);
+    completeTask(task.getId());
+
+    // when
+    taskService.deleteAttachment(attachment.getId());
+
+    // then
+    assertThat(selectAttachment(attachment.getId())).isNull();
+  }
+}

--- a/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/TaskAttachmentAuthorizationTest.java
+++ b/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/TaskAttachmentAuthorizationTest.java
@@ -77,6 +77,10 @@ public class TaskAttachmentAuthorizationTest extends AuthorizationTest {
       if (task != null) {
         taskService.deleteTask(TASK_ID, true);
       }
+      // a completed standalone task leaves history behind that no deployment cleanup covers
+      if (historyService.createHistoricTaskInstanceQuery().taskId(TASK_ID).count() > 0) {
+        historyService.deleteHistoricTaskInstance(TASK_ID);
+      }
       return null;
     });
   }
@@ -798,5 +802,38 @@ public class TaskAttachmentAuthorizationTest extends AuthorizationTest {
 
     // then
     assertThat(selectAttachment(attachment.getId())).isNull();
+  }
+
+  @Test
+  public void shouldReadAttachmentOfCompletedStandaloneTaskWithoutHistoricInstancePermissions() {
+    // a standalone task carries no process definition key, so with enableHistoricInstancePermissions
+    // off neither branch of the disjunction can ever match. Denying here would be stricter than the
+    // historic queries, which return such a task without any permission.
+    // given
+    createTask(TASK_ID);
+    Attachment attachment = createAttachment(TASK_ID, null);
+    completeTask(TASK_ID);
+
+    // when/then
+    assertThat(taskService.getAttachment(attachment.getId())).isNotNull();
+    assertThat(taskService.getAttachmentContent(attachment.getId())).isNotNull();
+    assertThat(taskService.getTaskAttachments(TASK_ID)).hasSize(1);
+    // the engine's own historic query agrees: no permission needed for this task
+    assertThat(historyService.createHistoricTaskInstanceQuery().taskId(TASK_ID).singleResult()).isNotNull();
+  }
+
+  @Test
+  public void shouldNotReadAttachmentOfCompletedStandaloneTaskWithHistoricInstancePermissions() {
+    // with the flag on, the per-instance permission exists and is enforced
+    // given
+    processEngineConfiguration.setEnableHistoricInstancePermissions(true);
+    createTask(TASK_ID);
+    Attachment attachment = createAttachment(TASK_ID, null);
+    completeTask(TASK_ID);
+
+    // when/then
+    assertThatThrownBy(() -> taskService.getAttachment(attachment.getId()))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'READ' permission on resource '" + TASK_ID + "' of type 'HistoricTask'");
   }
 }

--- a/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/TaskAttachmentAuthorizationTest.java
+++ b/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/TaskAttachmentAuthorizationTest.java
@@ -23,6 +23,7 @@ import static org.cibseven.bpm.engine.authorization.Permissions.READ_TASK;
 import static org.cibseven.bpm.engine.authorization.Permissions.TASK_WORK;
 import static org.cibseven.bpm.engine.authorization.Permissions.UPDATE;
 import static org.cibseven.bpm.engine.authorization.Permissions.UPDATE_TASK;
+import static org.cibseven.bpm.engine.authorization.Resources.HISTORIC_TASK;
 import static org.cibseven.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
 import static org.cibseven.bpm.engine.authorization.Resources.TASK;
 
@@ -30,6 +31,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 
 import org.cibseven.bpm.engine.AuthorizationException;
+import org.cibseven.bpm.engine.authorization.HistoricTaskPermissions;
 import org.cibseven.bpm.engine.task.Attachment;
 import org.cibseven.bpm.engine.task.Task;
 import org.cibseven.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
@@ -59,6 +61,8 @@ public class TaskAttachmentAuthorizationTest extends AuthorizationTest {
   @After
   public void resetAttachmentPermissions() {
     processEngineConfiguration.setEnforceAttachmentPermissions(false);
+    // individual tests switch this on for the historic read fallback
+    processEngineConfiguration.setEnableHistoricInstancePermissions(false);
   }
 
   /**
@@ -626,9 +630,11 @@ public class TaskAttachmentAuthorizationTest extends AuthorizationTest {
 
   @Test
   @Deployment(resources = ONE_TASK_PROCESS)
-  public void shouldNotCheckAuthorizationForAttachmentOfCompletedTask() {
-    // known limitation of CIB7-1752: once the runtime task is gone the attachment only lives in
-    // ACT_HI_ATTACHMENT and no CommandChecker method can authorize it
+  public void shouldNotCheckAuthorizationForAttachmentOfCompletedTaskWithoutHistoricPermissions() {
+    // once the runtime task is gone the attachment only lives in ACT_HI_ATTACHMENT. The historic
+    // read fallback needs enableHistoricInstancePermissions, which is off here, so nothing is
+    // checked. See shouldNotReadAttachmentOfCompletedTaskWithoutHistoricReadPermission for the
+    // enabled case.
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     Task task = selectSingleTask();
@@ -640,6 +646,62 @@ public class TaskAttachmentAuthorizationTest extends AuthorizationTest {
     assertThat(taskService.getTaskAttachment(task.getId(), attachment.getId())).isNotNull();
     assertThat(taskService.getAttachment(attachment.getId())).isNotNull();
     assertThat(taskService.getAttachmentContent(attachment.getId())).isNotNull();
+  }
+
+  // historic read fallback //////////////////////////////////////////////////
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldNotReadAttachmentOfCompletedTaskWithoutHistoricReadPermission() {
+    // given
+    processEngineConfiguration.setEnableHistoricInstancePermissions(true);
+    startProcessInstanceByKey(PROCESS_KEY);
+    Task task = selectSingleTask();
+    Attachment attachment = createAttachment(task.getId(), null);
+    completeTask(task.getId());
+
+    // when/then
+    assertThatThrownBy(() -> taskService.getAttachment(attachment.getId()))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'READ' permission on resource '" + task.getId() + "' of type 'HistoricTask'");
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldReadAttachmentOfCompletedTaskWithHistoricReadPermission() {
+    // given
+    processEngineConfiguration.setEnableHistoricInstancePermissions(true);
+    startProcessInstanceByKey(PROCESS_KEY);
+    Task task = selectSingleTask();
+    Attachment attachment = createAttachment(task.getId(), null);
+    completeTask(task.getId());
+    createGrantAuthorization(HISTORIC_TASK, task.getId(), userId, HistoricTaskPermissions.READ);
+
+    // when/then
+    assertThat(taskService.getAttachment(attachment.getId())).isNotNull();
+    assertThat(taskService.getAttachmentContent(attachment.getId())).isNotNull();
+    assertThat(taskService.getTaskAttachments(task.getId())).hasSize(1);
+    assertThat(taskService.getTaskAttachment(task.getId(), attachment.getId())).isNotNull();
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldStillNotCheckDeleteOfCompletedTaskAttachmentWithHistoricPermissions() {
+    // remaining gap of CIB7-1752: HistoricTaskPermissions defines READ only, so there is nothing to
+    // check update and delete against once the runtime task is gone. Enabling the historic
+    // permissions does not change that.
+    // given
+    processEngineConfiguration.setEnableHistoricInstancePermissions(true);
+    startProcessInstanceByKey(PROCESS_KEY);
+    Task task = selectSingleTask();
+    Attachment attachment = createAttachment(task.getId(), null);
+    completeTask(task.getId());
+
+    // when
+    taskService.deleteAttachment(attachment.getId());
+
+    // then
+    assertThat(selectAttachment(attachment.getId())).isNull();
   }
 
   // enforceAttachmentPermissions disabled /////////////////////////////////////

--- a/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/TaskAttachmentAuthorizationTest.java
+++ b/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/TaskAttachmentAuthorizationTest.java
@@ -18,6 +18,7 @@ package org.cibseven.bpm.engine.test.api.authorization;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.cibseven.bpm.engine.authorization.Permissions.DELETE_HISTORY;
 import static org.cibseven.bpm.engine.authorization.Permissions.READ;
 import static org.cibseven.bpm.engine.authorization.Permissions.READ_HISTORY;
 import static org.cibseven.bpm.engine.authorization.Permissions.READ_TASK;
@@ -704,16 +705,62 @@ public class TaskAttachmentAuthorizationTest extends AuthorizationTest {
 
   @Test
   @Deployment(resources = ONE_TASK_PROCESS)
-  public void shouldStillNotCheckDeleteOfCompletedTaskAttachmentWithHistoricPermissions() {
-    // remaining gap of CIB7-1752: HistoricTaskPermissions defines READ only, so there is nothing to
-    // check update and delete against once the runtime task is gone. Enabling the historic
-    // permissions does not change that.
+  public void shouldNotDeleteCompletedTaskAttachmentWithoutDeleteHistory() {
     // given
-    processEngineConfiguration.setEnableHistoricInstancePermissions(true);
     startProcessInstanceByKey(PROCESS_KEY);
     Task task = selectSingleTask();
     Attachment attachment = createAttachment(task.getId(), null);
     completeTask(task.getId());
+
+    // when/then
+    assertThatThrownBy(() -> taskService.deleteAttachment(attachment.getId()))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'DELETE_HISTORY' permission on resource '" + PROCESS_KEY + "' of type 'ProcessDefinition'");
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldDeleteCompletedTaskAttachmentWithDeleteHistory() {
+    // given
+    startProcessInstanceByKey(PROCESS_KEY);
+    Task task = selectSingleTask();
+    Attachment attachment = createAttachment(task.getId(), null);
+    completeTask(task.getId());
+    createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, DELETE_HISTORY);
+
+    // when
+    taskService.deleteAttachment(attachment.getId());
+
+    // then
+    assertThat(selectAttachment(attachment.getId())).isNull();
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldNotSaveCompletedTaskAttachmentWithoutDeleteHistory() {
+    // saving mutates historic data just like deleting, so it takes the same permission
+    // given
+    startProcessInstanceByKey(PROCESS_KEY);
+    Task task = selectSingleTask();
+    Attachment attachment = createAttachment(task.getId(), null);
+    completeTask(task.getId());
+    attachment.setName("aNewName");
+
+    // when/then
+    assertThatThrownBy(() -> taskService.saveAttachment(attachment))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'DELETE_HISTORY' permission on resource '" + PROCESS_KEY + "' of type 'ProcessDefinition'");
+  }
+
+  @Test
+  public void shouldStillNotCheckDeleteOfCompletedStandaloneTaskAttachment() {
+    // remaining gap: a standalone task carries no process definition key, and
+    // checkDeleteHistoricTaskInstance silently passes in that case. HistoricTaskPermissions defines
+    // no write permission that could take its place.
+    // given
+    createTask(TASK_ID);
+    Attachment attachment = createAttachment(TASK_ID, null);
+    completeTask(TASK_ID);
 
     // when
     taskService.deleteAttachment(attachment.getId());
@@ -779,23 +826,6 @@ public class TaskAttachmentAuthorizationTest extends AuthorizationTest {
     processEngineConfiguration.setEnforceAttachmentPermissions(false);
     createTask(TASK_ID);
     Attachment attachment = createAttachment(TASK_ID, null);
-
-    // when
-    taskService.deleteAttachment(attachment.getId());
-
-    // then
-    assertThat(selectAttachment(attachment.getId())).isNull();
-  }
-
-  @Test
-  @Deployment(resources = ONE_TASK_PROCESS)
-  public void shouldNotCheckAuthorizationWhenDeletingAttachmentOfCompletedTask() {
-    // known limitation of CIB7-1752, see above
-    // given
-    startProcessInstanceByKey(PROCESS_KEY);
-    Task task = selectSingleTask();
-    Attachment attachment = createAttachment(task.getId(), null);
-    completeTask(task.getId());
 
     // when
     taskService.deleteAttachment(attachment.getId());

--- a/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/TaskAttachmentAuthorizationTest.java
+++ b/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/TaskAttachmentAuthorizationTest.java
@@ -19,6 +19,7 @@ package org.cibseven.bpm.engine.test.api.authorization;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.cibseven.bpm.engine.authorization.Permissions.READ;
+import static org.cibseven.bpm.engine.authorization.Permissions.READ_HISTORY;
 import static org.cibseven.bpm.engine.authorization.Permissions.READ_TASK;
 import static org.cibseven.bpm.engine.authorization.Permissions.TASK_WORK;
 import static org.cibseven.bpm.engine.authorization.Permissions.UPDATE;
@@ -630,16 +631,29 @@ public class TaskAttachmentAuthorizationTest extends AuthorizationTest {
 
   @Test
   @Deployment(resources = ONE_TASK_PROCESS)
-  public void shouldNotCheckAuthorizationForAttachmentOfCompletedTaskWithoutHistoricPermissions() {
-    // once the runtime task is gone the attachment only lives in ACT_HI_ATTACHMENT. The historic
-    // read fallback needs enableHistoricInstancePermissions, which is off here, so nothing is
-    // checked. See shouldNotReadAttachmentOfCompletedTaskWithoutHistoricReadPermission for the
-    // enabled case.
+  public void shouldNotReadAttachmentOfCompletedTaskWithoutAnyHistoricPermission() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     Task task = selectSingleTask();
     Attachment attachment = createAttachment(task.getId(), null);
     completeTask(task.getId());
+
+    // when/then
+    assertThatThrownBy(() -> taskService.getAttachment(attachment.getId()))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'READ_HISTORY' permission on resource '" + PROCESS_KEY + "' of type 'ProcessDefinition'")
+        .hasMessageContaining("'READ' permission on resource '" + task.getId() + "' of type 'HistoricTask'");
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldReadAttachmentOfCompletedTaskWithReadHistoryOnProcessDefinition() {
+    // given
+    startProcessInstanceByKey(PROCESS_KEY);
+    Task task = selectSingleTask();
+    Attachment attachment = createAttachment(task.getId(), null);
+    completeTask(task.getId());
+    createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_HISTORY);
 
     // when/then
     assertThat(taskService.getTaskAttachments(task.getId())).hasSize(1);

--- a/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/TaskAttachmentAuthorizationTest.java
+++ b/engine/src/test/java/org/cibseven/bpm/engine/test/api/authorization/TaskAttachmentAuthorizationTest.java
@@ -280,6 +280,86 @@ public class TaskAttachmentAuthorizationTest extends AuthorizationTest {
     assertThat(selectAttachment(attachment.getId())).isNull();
   }
 
+  // save attachment /////////////////////////////////////////////////////////
+
+  @Test
+  public void shouldNotSaveStandaloneTaskAttachmentWithoutAuthorization() {
+    // given
+    createTask(TASK_ID);
+    Attachment attachment = createAttachment(TASK_ID, null);
+    attachment.setName("renamedByAttacker");
+
+    // when/then
+    assertThatThrownBy(() -> taskService.saveAttachment(attachment))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'TASK_WORK' permission on resource 'myTask' of type 'Task'");
+
+    assertThat(selectAttachment(attachment.getId()).getName()).isEqualTo("aName");
+  }
+
+  @Test
+  public void shouldNotSaveStandaloneTaskAttachmentWithReadPermissionOnly() {
+    // given
+    createTask(TASK_ID);
+    Attachment attachment = createAttachment(TASK_ID, null);
+    attachment.setName("renamedByAttacker");
+    createGrantAuthorization(TASK, TASK_ID, userId, READ);
+
+    // when/then
+    assertThatThrownBy(() -> taskService.saveAttachment(attachment))
+        .isInstanceOf(AuthorizationException.class);
+  }
+
+  @Test
+  public void shouldSaveStandaloneTaskAttachmentWithUpdatePermission() {
+    // given
+    createTask(TASK_ID);
+    Attachment attachment = createAttachment(TASK_ID, null);
+    attachment.setName("updatedName");
+    attachment.setDescription("updatedDescription");
+    createGrantAuthorization(TASK, TASK_ID, userId, UPDATE);
+
+    // when
+    taskService.saveAttachment(attachment);
+
+    // then
+    Attachment updated = selectAttachment(attachment.getId());
+    assertThat(updated.getName()).isEqualTo("updatedName");
+    assertThat(updated.getDescription()).isEqualTo("updatedDescription");
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldNotSaveProcessTaskAttachmentWithoutAuthorization() {
+    // given
+    startProcessInstanceByKey(PROCESS_KEY);
+    Task task = selectSingleTask();
+    Attachment attachment = createAttachment(task.getId(), null);
+    attachment.setName("renamedByAttacker");
+
+    // when/then
+    assertThatThrownBy(() -> taskService.saveAttachment(attachment))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("'UPDATE_TASK' permission on resource 'oneTaskProcess' of type 'ProcessDefinition'");
+  }
+
+  @Test
+  @Deployment(resources = ONE_TASK_PROCESS)
+  public void shouldSaveProcessTaskAttachmentWithUpdateTaskPermissionOnProcessDefinition() {
+    // given
+    startProcessInstanceByKey(PROCESS_KEY);
+    Task task = selectSingleTask();
+    Attachment attachment = createAttachment(task.getId(), null);
+    attachment.setName("updatedName");
+    createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_TASK);
+
+    // when
+    taskService.saveAttachment(attachment);
+
+    // then
+    assertThat(selectAttachment(attachment.getId()).getName()).isEqualTo("updatedName");
+  }
+
   // get task attachments ////////////////////////////////////////////////////
 
   @Test
@@ -596,6 +676,21 @@ public class TaskAttachmentAuthorizationTest extends AuthorizationTest {
 
     // then
     assertThat(attachment).isNotNull();
+  }
+
+  @Test
+  public void shouldNotCheckSaveWhenEnforcementDisabled() {
+    // given
+    processEngineConfiguration.setEnforceAttachmentPermissions(false);
+    createTask(TASK_ID);
+    Attachment attachment = createAttachment(TASK_ID, null);
+    attachment.setName("updatedName");
+
+    // when
+    taskService.saveAttachment(attachment);
+
+    // then - the behaviour before CIB7-1752, no permission needed at all
+    assertThat(selectAttachment(attachment.getId()).getName()).isEqualTo("updatedName");
   }
 
   @Test

--- a/engine/src/test/java/org/cibseven/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyAttachmentCmdsTenantCheckTest.java
+++ b/engine/src/test/java/org/cibseven/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyAttachmentCmdsTenantCheckTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cibseven.bpm.engine.test.api.multitenancy.tenantcheck;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Collections;
+
+import org.cibseven.bpm.engine.HistoryService;
+import org.cibseven.bpm.engine.IdentityService;
+import org.cibseven.bpm.engine.ProcessEngineConfiguration;
+import org.cibseven.bpm.engine.ProcessEngineException;
+import org.cibseven.bpm.engine.RuntimeService;
+import org.cibseven.bpm.engine.TaskService;
+import org.cibseven.bpm.engine.history.HistoricProcessInstance;
+import org.cibseven.bpm.engine.history.HistoricTaskInstance;
+import org.cibseven.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.cibseven.bpm.engine.task.Attachment;
+import org.cibseven.bpm.engine.task.Task;
+import org.cibseven.bpm.engine.test.ProcessEngineRule;
+import org.cibseven.bpm.engine.test.RequiredHistoryLevel;
+import org.cibseven.bpm.engine.test.util.ProcessEngineTestRule;
+import org.cibseven.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.cibseven.bpm.model.bpmn.Bpmn;
+import org.cibseven.bpm.model.bpmn.BpmnModelInstance;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+/**
+ * Tenant isolation of the attachment commands once the owning task or process instance has
+ * completed, see CIB7-1752. The runtime paths are already covered by the task and process instance
+ * tenant checks, these tests pin the historic fallback that CommandChecker#checkModifyHistoricTaskInstance
+ * and CommandChecker#checkModifyHistoricProcessInstance guard.
+ */
+@RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
+public class MultiTenancyAttachmentCmdsTenantCheckTest {
+
+  protected static final String TENANT_ONE = "tenant1";
+  protected static final String TENANT_TWO = "tenant2";
+
+  protected static final String PROCESS_DEFINITION_KEY = "oneTaskProcess";
+
+  protected static final BpmnModelInstance ONE_TASK_PROCESS = Bpmn
+      .createExecutableProcess(PROCESS_DEFINITION_KEY)
+      .startEvent()
+      .userTask("task1")
+      .endEvent()
+      .done();
+
+  protected ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
+
+  protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
+
+  @Rule
+  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testRule);
+
+  protected IdentityService identityService;
+  protected RuntimeService runtimeService;
+  protected TaskService taskService;
+  protected HistoryService historyService;
+  protected ProcessEngineConfigurationImpl processEngineConfiguration;
+
+  @Before
+  public void init() {
+    identityService = engineRule.getIdentityService();
+    runtimeService = engineRule.getRuntimeService();
+    taskService = engineRule.getTaskService();
+    historyService = engineRule.getHistoryService();
+    processEngineConfiguration = engineRule.getProcessEngineConfiguration();
+
+    // the attachment checks are off by default, and the tenant check rides along with them
+    processEngineConfiguration.setEnforceAttachmentPermissions(true);
+  }
+
+  @After
+  public void tearDown() {
+    identityService.clearAuthentication();
+    processEngineConfiguration.setEnforceAttachmentPermissions(false);
+    processEngineConfiguration.setTenantCheckEnabled(false);
+
+    for (HistoricTaskInstance instance : historyService.createHistoricTaskInstanceQuery().list()) {
+      historyService.deleteHistoricTaskInstance(instance.getId());
+    }
+    for (HistoricProcessInstance instance : historyService.createHistoricProcessInstanceQuery().list()) {
+      historyService.deleteHistoricProcessInstance(instance.getId());
+    }
+    processEngineConfiguration.setTenantCheckEnabled(true);
+  }
+
+  // completed standalone task ///////////////////////////////////////////////
+
+  @Test
+  public void failToDeleteAttachmentOfCompletedTaskOfOtherTenant() {
+    String attachmentId = createAttachmentForCompletedTask(TENANT_ONE);
+
+    identityService.setAuthentication("user", null, Collections.singletonList(TENANT_TWO));
+
+    // when/then
+    assertThatThrownBy(() -> taskService.deleteAttachment(attachmentId))
+        .isInstanceOf(ProcessEngineException.class)
+        .hasMessageContaining("Cannot modify the historic task instance");
+  }
+
+  @Test
+  public void failToSaveAttachmentOfCompletedTaskWithNoAuthenticatedTenant() {
+    String attachmentId = createAttachmentForCompletedTask(TENANT_ONE);
+    Attachment attachment = taskService.getAttachment(attachmentId);
+    attachment.setName("aNewName");
+
+    identityService.setAuthentication("user", null, null);
+
+    // when/then
+    assertThatThrownBy(() -> taskService.saveAttachment(attachment))
+        .isInstanceOf(ProcessEngineException.class)
+        .hasMessageContaining("Cannot modify the historic task instance");
+  }
+
+  @Test
+  public void deleteAttachmentOfCompletedTaskWithAuthenticatedTenant() {
+    String attachmentId = createAttachmentForCompletedTask(TENANT_ONE);
+
+    identityService.setAuthentication("user", null, Collections.singletonList(TENANT_ONE));
+
+    // when
+    taskService.deleteAttachment(attachmentId);
+
+    // then
+    identityService.clearAuthentication();
+    assertThat(taskService.getAttachment(attachmentId)).isNull();
+  }
+
+  @Test
+  public void deleteAttachmentOfCompletedTaskWithDisabledTenantCheck() {
+    String attachmentId = createAttachmentForCompletedTask(TENANT_ONE);
+
+    identityService.setAuthentication("user", null, null);
+    processEngineConfiguration.setTenantCheckEnabled(false);
+
+    // when
+    taskService.deleteAttachment(attachmentId);
+
+    // then
+    assertThat(taskService.getAttachment(attachmentId)).isNull();
+  }
+
+  // completed process instance //////////////////////////////////////////////
+
+  @Test
+  public void failToDeleteAttachmentOfCompletedProcessInstanceOfOtherTenant() {
+    String attachmentId = createAttachmentForCompletedProcessInstance(TENANT_ONE);
+
+    identityService.setAuthentication("user", null, Collections.singletonList(TENANT_TWO));
+
+    // when/then
+    assertThatThrownBy(() -> taskService.deleteAttachment(attachmentId))
+        .isInstanceOf(ProcessEngineException.class)
+        .hasMessageContaining("Cannot modify the historic process instance");
+  }
+
+  @Test
+  public void deleteAttachmentOfCompletedProcessInstanceWithAuthenticatedTenant() {
+    String attachmentId = createAttachmentForCompletedProcessInstance(TENANT_ONE);
+
+    identityService.setAuthentication("user", null, Collections.singletonList(TENANT_ONE));
+
+    // when
+    taskService.deleteAttachment(attachmentId);
+
+    // then
+    identityService.clearAuthentication();
+    assertThat(taskService.getAttachment(attachmentId)).isNull();
+  }
+
+  // helpers /////////////////////////////////////////////////////////////////
+
+  /**
+   * Attaches to a standalone task and completes it, so that only the historic task remains.
+   */
+  protected String createAttachmentForCompletedTask(String tenantId) {
+    Task task = taskService.newTask();
+    task.setTenantId(tenantId);
+    taskService.saveTask(task);
+
+    Attachment attachment = taskService.createAttachment("foo", task.getId(), null, "aName",
+        "aDescription", "http://cibseven.org");
+
+    taskService.complete(task.getId());
+
+    return attachment.getId();
+  }
+
+  protected String createAttachmentForCompletedProcessInstance(String tenantId) {
+    testRule.deployForTenant(tenantId, ONE_TASK_PROCESS);
+
+    String processInstanceId = runtimeService.createProcessInstanceByKey(PROCESS_DEFINITION_KEY)
+        .processDefinitionTenantId(tenantId)
+        .execute()
+        .getId();
+
+    Attachment attachment = taskService.createAttachment("foo", null, processInstanceId, "aName",
+        "aDescription", "http://cibseven.org");
+
+    Task task = taskService.createTaskQuery().processInstanceId(processInstanceId).singleResult();
+    taskService.complete(task.getId());
+
+    return attachment.getId();
+  }
+}


### PR DESCRIPTION
The task and process instance attachment commands resolved their entity from a caller supplied id and performed the read or write without ever consulting CommandChecker, so no permission could be enforced no matter how authorization was configured. Affects CreateAttachmentCmd, DeleteAttachmentCmd, GetAttachmentCmd, GetAttachmentContentCmd, GetProcessInstanceAttachmentsCmd, GetTaskAttachmentCmd, GetTaskAttachmentContentCmd and GetTaskAttachmentsCmd.

The checks are gated by the new enforceAttachmentPermissions configuration option, which is disabled by default, following enforceSpecificVariablePermission and enableHistoricInstancePermissions. While disabled the commands behave exactly as before, including the tenant checks, and resolve no extra entity.

Once enabled, reads require READ on TASK or READ_TASK on PROCESS_DEFINITION, and READ on PROCESS_INSTANCE or READ_INSTANCE on PROCESS_DEFINITION for the process instance variants. Writes require TASK_WORK or UPDATE, respectively UPDATE or UPDATE_INSTANCE.

TaskAttachmentResourceImpl now rethrows AuthorizationException before its ProcessEngineException handlers, so the create and delete endpoints answer 403 instead of 400 and 404.

Known limitation: for completed tasks and process instances the runtime entity is gone, so the attachments remaining in ACT_HI_ATTACHMENT stay readable without a permission. Closing that requires a history check that CommandChecker does not offer today.

CIB7-1752