### PR TITLE
fix(distro): ship caffeine with the LDAP cache on WildFly and Tomcat

### DIFF
--- a/distro/tomcat/assembly/assembly.xml
+++ b/distro/tomcat/assembly/assembly.xml
@@ -41,6 +41,7 @@
         <include>org.cibseven.bpm:cibseven-engine:jar</include>
         <include>org.cibseven.bpm.identity:cibseven-identity-ldap:jar</include>
         <include>org.cibseven.bpm.identity:cibseven-identity-scim:jar</include>
+        <include>com.github.ben-manes.caffeine:caffeine:jar</include>
 
         <include>org.mybatis:mybatis:jar:*</include>
         <include>com.fasterxml.uuid:java-uuid-generator:jar:*</include>
@@ -87,6 +88,7 @@
         <include>org.cibseven.bpm:cibseven-engine:jar</include>
         <include>org.cibseven.bpm.identity:cibseven-identity-ldap:jar</include>
         <include>org.cibseven.bpm.identity:cibseven-identity-scim:jar</include>
+        <include>com.github.ben-manes.caffeine:caffeine:jar</include>
 
         <include>org.mybatis:mybatis:jar:*</include>
         <include>com.fasterxml.uuid:java-uuid-generator:jar:*</include>

--- a/distro/wildfly/modules/pom.xml
+++ b/distro/wildfly/modules/pom.xml
@@ -297,6 +297,18 @@
                 </copy>
                 <delete dir="target/modules/org/apache/httpcomponents/core5/httpcore5-h2" />
 
+                <!-- move caffeine into its own slot, so that we do not shadow the
+                  caffeine module WildFly provides for Infinispan -->
+                <delete dir="target/modules/com/github/ben-manes/caffeine" />
+                <copy todir="target/modules" flatten="false">
+                  <fileset refid="maven.project.dependencies" />
+                  <mapper>
+                    <chainedmapper>
+                      <regexpmapper from="^(com.github.ben-manes.caffeine)/caffeine/[^/]+/(caffeine-.*\.jar)$$" to="\1/cibseven/\2" handledirsep="yes" />
+                    </chainedmapper>
+                  </mapper>
+                </copy>
+
                 <!-- copy groovy dependencies to single dir -->
                 <delete dir="target/modules/org/apache/groovy" />
                 <copy todir="target/modules" flatten="false">
@@ -391,6 +403,10 @@
                 </replace>
 
                 <replace dir="target/modules" token="@version.accessors-smart@" value="${version.accessors-smart}">
+                  <include name="**/module.xml" />
+                </replace>
+
+                <replace dir="target/modules" token="@version.caffeine@" value="${version.caffeine}">
                   <include name="**/module.xml" />
                 </replace>
 

--- a/distro/wildfly/modules/src/main/modules/com/github/ben-manes/caffeine/cibseven/module.xml
+++ b/distro/wildfly/modules/src/main/modules/com/github/ben-manes/caffeine/cibseven/module.xml
@@ -1,0 +1,18 @@
+<!--
+  ~ WildFly ships its own com.github.ben-manes.caffeine module (for Infinispan),
+  ~ but it is declared jboss.api=private and its version is tied to the WildFly
+  ~ release. We therefore ship the caffeine version the engine plugins are built
+  ~ against in a dedicated slot, so that we neither depend on a private module
+  ~ nor shadow the one the container uses internally.
+  -->
+<module xmlns="urn:jboss:module:1.1" name="com.github.ben-manes.caffeine" slot="cibseven">
+  <resources>
+    <resource-root path="caffeine-@version.caffeine@.jar" />
+  </resources>
+
+  <dependencies>
+    <module name="java.base" />
+    <module name="java.logging" />
+    <module name="jdk.unsupported" />
+  </dependencies>
+</module>

--- a/distro/wildfly/modules/src/main/modules/org/cibseven/bpm/identity/cibseven-identity-ldap/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/cibseven/bpm/identity/cibseven-identity-ldap/main/module.xml
@@ -9,6 +9,8 @@
     <module name="java.naming" />
     <module name="org.cibseven.bpm.cibseven-engine" />
     <module name="org.cibseven.commons.cibseven-commons-logging" />
+    <!-- optional LDAP lookup caching -->
+    <module name="com.github.ben-manes.caffeine" slot="cibseven" />
 
   </dependencies>
 </module>

--- a/distro/wildfly28/modules/pom.xml
+++ b/distro/wildfly28/modules/pom.xml
@@ -281,6 +281,18 @@
                 </copy>
                 <delete dir="target/modules/org/apache/httpcomponents/core5/httpcore5-h2" />
 
+                <!-- move caffeine into its own slot, so that we do not shadow the
+                  caffeine module WildFly provides for Infinispan -->
+                <delete dir="target/modules/com/github/ben-manes/caffeine" />
+                <copy todir="target/modules" flatten="false">
+                  <fileset refid="maven.project.dependencies" />
+                  <mapper>
+                    <chainedmapper>
+                      <regexpmapper from="^(com.github.ben-manes.caffeine)/caffeine/[^/]+/(caffeine-.*\.jar)$$" to="\1/cibseven/\2" handledirsep="yes" />
+                    </chainedmapper>
+                  </mapper>
+                </copy>
+
                 <!-- copy groovy dependencies to single dir -->
                 <delete dir="target/modules/org/apache/groovy" />
                 <copy todir="target/modules" flatten="false">
@@ -359,6 +371,10 @@
                 </replace>
 
                 <replace dir="target/modules" token="@version.accessors-smart@" value="${version.accessors-smart}">
+                  <include name="**/module.xml" />
+                </replace>
+
+                <replace dir="target/modules" token="@version.caffeine@" value="${version.caffeine}">
                   <include name="**/module.xml" />
                 </replace>
 

--- a/distro/wildfly28/modules/src/main/modules/com/github/ben-manes/caffeine/cibseven/module.xml
+++ b/distro/wildfly28/modules/src/main/modules/com/github/ben-manes/caffeine/cibseven/module.xml
@@ -1,0 +1,18 @@
+<!--
+  ~ WildFly ships its own com.github.ben-manes.caffeine module (for Infinispan),
+  ~ but it is declared jboss.api=private and its version is tied to the WildFly
+  ~ release. We therefore ship the caffeine version the engine plugins are built
+  ~ against in a dedicated slot, so that we neither depend on a private module
+  ~ nor shadow the one the container uses internally.
+  -->
+<module xmlns="urn:jboss:module:1.1" name="com.github.ben-manes.caffeine" slot="cibseven">
+  <resources>
+    <resource-root path="caffeine-@version.caffeine@.jar" />
+  </resources>
+
+  <dependencies>
+    <module name="java.base" />
+    <module name="java.logging" />
+    <module name="jdk.unsupported" />
+  </dependencies>
+</module>

--- a/distro/wildfly28/modules/src/main/modules/org/cibseven/bpm/identity/cibseven-identity-ldap/main/module.xml
+++ b/distro/wildfly28/modules/src/main/modules/org/cibseven/bpm/identity/cibseven-identity-ldap/main/module.xml
@@ -9,6 +9,8 @@
     <module name="java.naming" />
     <module name="org.cibseven.bpm.cibseven-engine" />
     <module name="org.cibseven.commons.cibseven-commons-logging" />
+    <!-- optional LDAP lookup caching -->
+    <module name="com.github.ben-manes.caffeine" slot="cibseven" />
 
   </dependencies>
 </module>

--- a/qa/tomcat10-runtime/src/assembly.xml
+++ b/qa/tomcat10-runtime/src/assembly.xml
@@ -31,6 +31,7 @@
 
         <include>org.cibseven.bpm:cibseven-engine:jar</include>
         <include>org.cibseven.bpm.identity:cibseven-identity-ldap:jar</include>
+        <include>com.github.ben-manes.caffeine:caffeine:jar</include>
 
         <include>org.mybatis:mybatis:jar:*</include>
         <include>com.fasterxml.uuid:java-uuid-generator:jar:*</include>
@@ -74,6 +75,7 @@
 
         <include>org.cibseven.bpm:cibseven-engine:jar</include>
         <include>org.cibseven.bpm.identity:cibseven-identity-ldap:jar</include>
+        <include>com.github.ben-manes.caffeine:caffeine:jar</include>
 
         <include>org.mybatis:mybatis:jar:*</include>
         <include>com.fasterxml.uuid:java-uuid-generator:jar:*</include>

--- a/qa/tomcat9-runtime/src/assembly.xml
+++ b/qa/tomcat9-runtime/src/assembly.xml
@@ -32,6 +32,7 @@
         <include>org.cibseven.bpm:cibseven-engine:jar</include>
         <include>org.cibseven.bpm.identity:cibseven-identity-ldap:jar</include>
         <include>org.cibseven.bpm.identity:cibseven-identity-scim:jar</include>
+        <include>com.github.ben-manes.caffeine:caffeine:jar</include>
 
         <include>org.mybatis:mybatis:jar:*</include>
         <include>com.fasterxml.uuid:java-uuid-generator:jar:*</include>
@@ -76,6 +77,7 @@
         <include>org.cibseven.bpm:cibseven-engine:jar</include>
         <include>org.cibseven.bpm.identity:cibseven-identity-ldap:jar</include>
         <include>org.cibseven.bpm.identity:cibseven-identity-scim:jar</include>
+        <include>com.github.ben-manes.caffeine:caffeine:jar</include>
 
         <include>org.mybatis:mybatis:jar:*</include>
         <include>com.fasterxml.uuid:java-uuid-generator:jar:*</include>


### PR DESCRIPTION
The optional LDAP lookup cache added in CIB7-1598 uses Caffeine, but no distribution actually shipped the library, so enabling the cache failed with NoClassDefFoundError on both containers.

WildFly: the antrun copy step placed caffeine under the artifactId directory (com/github/ben-manes/caffeine/caffeine/main), which does not match the module name, and no module.xml existed for it. Ship it in a dedicated "cibseven" slot instead.

Deliberately not reusing the caffeine module WildFly provides for Infinispan: it is declared jboss.api=private and its version follows the container release (3.1.6 on WildFly 28, 3.1.8 on 33/35), so it cannot be pinned to version.caffeine. A "main" slot of our own is not an option either, since the modules/ overlay is searched before modules/system/layers/base and would silently replace Infinispan's copy.

Tomcat: the assemblies use explicit include lists and caffeine was never listed, so it was missing from lib/ as well. Covers the distro assembly plus the tomcat9/tomcat10 QA runtimes; qa/tomcat-runtime consumes the distro assembly. The run/run4 distros resolve it transitively.

CIB7-1598