### PR TITLE
fix(engine): prevent GraalJS memory leak from polyglot Context accumulation

### DIFF
--- a/connect/http-client/src/main/java/org/cibseven/connect/httpclient/impl/HttpResponseImpl.java
+++ b/connect/http-client/src/main/java/org/cibseven/connect/httpclient/impl/HttpResponseImpl.java
@@ -59,31 +59,35 @@ public class HttpResponseImpl extends AbstractCloseableConnectorResponse impleme
   }
 
   protected void collectResponseParameters(Map<String, Object> responseParameters) {
-    responseParameters.put(PARAM_NAME_STATUS_CODE, httpResponse.getCode());
-    collectResponseHeaders();
+    ClassicHttpResponse localResponse = this.httpResponse;
+    try {
+      responseParameters.put(PARAM_NAME_STATUS_CODE, localResponse.getCode());
+      collectResponseHeaders(localResponse);
 
-    if (httpResponse.getEntity() != null) {
-      try {
-        String response = IoUtil.inputStreamAsString(httpResponse.getEntity().getContent());
-        responseParameters.put(PARAM_NAME_RESPONSE, response);
-      } catch (IOException e) {
-        throw LOG.unableToReadResponse(e);
-      } finally {
-        IoUtil.closeSilently(httpResponse);
+      if (localResponse.getEntity() != null) {
+        try {
+          String response = IoUtil.inputStreamAsString(localResponse.getEntity().getContent());
+          responseParameters.put(PARAM_NAME_RESPONSE, response);
+        } catch (IOException e) {
+          throw LOG.unableToReadResponse(e);
+        }
       }
+    } finally {
+      IoUtil.closeSilently(localResponse);
+      this.httpResponse = null;
     }
   }
 
-  protected void collectResponseHeaders() {
+  protected void collectResponseHeaders(ClassicHttpResponse response) {
     Map<String, String> headers = new HashMap<>();
-    for (Header header : httpResponse.getHeaders()) {
+    for (Header header : response.getHeaders()) {
       headers.put(header.getName(), header.getValue());
     }
     responseParameters.put(PARAM_NAME_RESPONSE_HEADERS, headers);
   }
 
   protected Closeable getClosable() {
-    return httpResponse;
+    return httpResponse != null ? httpResponse : () -> {};
   }
 
 }

--- a/connect/http-client/src/test/java/org/cibseven/connect/httpclient/HttpResponseTest.java
+++ b/connect/http-client/src/test/java/org/cibseven/connect/httpclient/HttpResponseTest.java
@@ -17,11 +17,13 @@
 package org.cibseven.connect.httpclient;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 import org.assertj.core.api.Assertions;
 import org.cibseven.connect.ConnectorRequestException;
 import org.cibseven.connect.httpclient.impl.HttpConnectorImpl;
 import org.cibseven.connect.impl.DebugRequestInterceptor;
+import org.cibseven.connect.spi.CloseableConnectorResponse;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -89,6 +91,28 @@ public class HttpResponseTest {
 
   protected HttpResponse getResponse() {
     return connector.createRequest().url("http://camunda.com").get().execute();
+  }
+
+  @Test
+  public void responseShouldBeClosableAfterReadingParameters() {
+    testResponse.code(200).payload("test body");
+    HttpResponse response = getResponse();
+    // access all parameters to trigger collectResponseParameters
+    assertThat(response.getStatusCode()).isEqualTo(200);
+    assertThat(response.getResponse()).isEqualTo("test body");
+    assertThat(response.getHeaders()).isNotNull();
+    // calling close() after parameters have been collected should not throw
+    assertThat(response).isInstanceOf(CloseableConnectorResponse.class);
+    assertThat(catchThrowable(response::close)).isNull();
+  }
+
+  @Test
+  public void responseShouldBeClosableWithoutReadingParameters() {
+    testResponse.code(200).payload("test body");
+    HttpResponse response = getResponse();
+    // close without ever reading parameters — should not throw
+    assertThat(response).isInstanceOf(CloseableConnectorResponse.class);
+    assertThat(catchThrowable(response::close)).isNull();
   }
 
   @Test

--- a/engine-dmn/engine/src/main/java/org/cibseven/bpm/dmn/engine/impl/DmnEngineLogger.java
+++ b/engine-dmn/engine/src/main/java/org/cibseven/bpm/dmn/engine/impl/DmnEngineLogger.java
@@ -119,4 +119,10 @@ public class DmnEngineLogger extends DmnLogger {
     );
   }
 
+  public void logClosingScriptEngineFailed(Exception e) {
+    logDebug(
+      "014",
+      "Failed to close script engine: {}", e.getMessage());
+  }
+
 }

--- a/engine-dmn/engine/src/main/java/org/cibseven/bpm/dmn/engine/impl/evaluation/ExpressionEvaluationHandler.java
+++ b/engine-dmn/engine/src/main/java/org/cibseven/bpm/dmn/engine/impl/evaluation/ExpressionEvaluationHandler.java
@@ -77,7 +77,7 @@ public class ExpressionEvaluationHandler {
     bindings.put("variableContext", variableContext);
 
     try {
-      if (scriptEngine instanceof Compilable) {
+      if (isCachableEngine(scriptEngine) && scriptEngine instanceof Compilable) {
 
         CompiledScript compiledScript = cachedCompiledScriptSupport.getCachedCompiledScript();
         if (compiledScript == null) {
@@ -101,6 +101,9 @@ public class ExpressionEvaluationHandler {
     }
     catch (ScriptException e) {
       throw LOG.unableToEvaluateExpression(expressionText, scriptEngine.getFactory().getLanguageName(), e);
+    }
+    finally {
+      closeNonCachedEngine(scriptEngine);
     }
   }
 
@@ -172,6 +175,31 @@ public class ExpressionEvaluationHandler {
       expressionLanguage.equals(DefaultDmnEngineConfiguration.FEEL_EXPRESSION_LANGUAGE_DMN13) ||
       expressionLanguage.equals(DefaultDmnEngineConfiguration.FEEL_EXPRESSION_LANGUAGE_DMN14) ||
       expressionLanguage.equals(DefaultDmnEngineConfiguration.FEEL_EXPRESSION_LANGUAGE_DMN15);
+  }
+
+  /**
+   * Checks whether the given script engine can be cached for reuse.
+   * An engine is cachable if its factory reports a non-null THREADING parameter.
+   * Non-cachable engines like GraalJS require special bindings handling to avoid
+   * creating additional polyglot Contexts per evaluation. They do not support the {@code THREADING} parameter.
+   */
+  protected static boolean isCachableEngine(ScriptEngine scriptEngine) {
+    return scriptEngine.getFactory().getParameter("THREADING") != null;
+  }
+
+  /**
+   * Closes a non-cached script engine that implements {@link AutoCloseable}.
+   * Script engines with {@code THREADING=null} (e.g., GraalJS) create a fresh instance
+   * per evaluation and must be explicitly closed to release their internal resources.
+   */
+  protected static void closeNonCachedEngine(ScriptEngine scriptEngine) {
+    if (scriptEngine instanceof AutoCloseable && !isCachableEngine(scriptEngine)) {
+      try {
+        ((AutoCloseable) scriptEngine).close();
+      } catch (Exception e) {
+        LOG.logClosingScriptEngineFailed(e);
+      }
+    }
   }
 
 }

--- a/engine-dmn/engine/src/test/java/org/cibseven/bpm/dmn/engine/el/ExpressionCachingTest.java
+++ b/engine-dmn/engine/src/test/java/org/cibseven/bpm/dmn/engine/el/ExpressionCachingTest.java
@@ -54,6 +54,11 @@ public class ExpressionCachingTest {
     when(scriptEngineSpy.compile(anyString())).thenReturn(mock(CompiledScript.class));
     when(scriptEngineManager.getEngineByName(anyString())).thenReturn(scriptEngineSpy);
 
+    // Stub factory so isCachableEngine() can check THREADING parameter
+    javax.script.ScriptEngineFactory factoryMock = mock(javax.script.ScriptEngineFactory.class);
+    when(factoryMock.getParameter("THREADING")).thenReturn("MULTITHREADED");
+    when(scriptEngineSpy.getFactory()).thenReturn(factoryMock);
+
     DefaultDmnEngineConfiguration configuration = new DefaultDmnEngineConfiguration();
 
     configuration.setScriptEngineResolver(new DefaultScriptEngineResolver(scriptEngineManager));

--- a/engine-plugins/connect-plugin/src/main/java/org/cibseven/connect/plugin/impl/ServiceTaskConnectorActivityBehavior.java
+++ b/engine-plugins/connect-plugin/src/main/java/org/cibseven/connect/plugin/impl/ServiceTaskConnectorActivityBehavior.java
@@ -17,6 +17,8 @@
 package org.cibseven.connect.plugin.impl;
 
 import java.util.concurrent.Callable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.cibseven.bpm.engine.impl.bpmn.behavior.TaskActivityBehavior;
 import org.cibseven.bpm.engine.impl.core.variable.mapping.IoMapping;
@@ -24,6 +26,7 @@ import org.cibseven.bpm.engine.impl.core.variable.scope.AbstractVariableScope;
 import org.cibseven.bpm.engine.impl.pvm.delegate.ActivityExecution;
 import org.cibseven.connect.ConnectorException;
 import org.cibseven.connect.Connectors;
+import org.cibseven.connect.spi.CloseableConnectorResponse;
 import org.cibseven.connect.spi.Connector;
 import org.cibseven.connect.spi.ConnectorRequest;
 import org.cibseven.connect.spi.ConnectorResponse;
@@ -33,6 +36,8 @@ import org.cibseven.connect.spi.ConnectorResponse;
  *
  */
 public class ServiceTaskConnectorActivityBehavior extends TaskActivityBehavior {
+
+  private static final Logger LOG = Logger.getLogger(ServiceTaskConnectorActivityBehavior.class.getName());
 
   /** the id of the connector */
   protected String connectorId;
@@ -59,7 +64,18 @@ public class ServiceTaskConnectorActivityBehavior extends TaskActivityBehavior {
         applyInputParameters(execution, request);
         // execute the request and obtain a response:
         ConnectorResponse response = request.execute();
-        applyOutputParameters(execution, response);
+        try {
+          applyOutputParameters(execution, response);
+        } finally {
+          if (response instanceof CloseableConnectorResponse) {
+            try {
+              ((CloseableConnectorResponse) response).close();
+            } catch (Exception e) {
+              // log and continue so that leave() is always reached
+              LOG.log(Level.WARNING, "Exception while closing connector response", e);
+            }
+          }
+        }
         leave(execution);
         return null;
       }

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/scripting/ScriptLogger.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/scripting/ScriptLogger.java
@@ -39,4 +39,9 @@ public class ScriptLogger extends ProcessEngineLogger {
         "001", "Evaluating non-compiled script {}", scriptSource);
   }
 
+  public void logClosingScriptEngineFailed(Exception e) {
+    logDebug(
+        "003", "Failed to close script engine: {}", e.getMessage());
+  }
+
 }

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/scripting/engine/ScriptingEngines.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/scripting/engine/ScriptingEngines.java
@@ -19,6 +19,7 @@ package org.cibseven.bpm.engine.impl.scripting.engine;
 import static org.cibseven.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 import javax.script.Bindings;
+import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineFactory;
 import javax.script.ScriptEngineManager;
@@ -149,7 +150,50 @@ public class ScriptingEngines implements DmnScriptEngineResolver {
    * @param engineBindin
    * @param scriptEngine */
   public Bindings createBindings(ScriptEngine scriptEngine, VariableScope variableScope) {
+    if (!isCachableEngine(scriptEngine)) {
+      return createBindingsForNonCachableEngine(scriptEngine, variableScope);
+    }
     return scriptBindingsFactory.createBindings(variableScope, scriptEngine.createBindings());
+  }
+
+  /**
+   * Creates bindings for non-cachable script engines (e.g., GraalJS) by using the engine's
+   * default ENGINE_SCOPE bindings directly, populated with resolver values.
+   * <p>
+   * This avoids wrapping the engine's bindings in {@link ScriptBindings}, which would cause
+   * GraalJS to create additional polyglot Contexts during evaluation. GraalJS checks if
+   * ENGINE_SCOPE bindings are {@code GraalJSBindings} and creates a new polyglot Context
+   * when they are not. By using the engine's default bindings (which ARE GraalJSBindings),
+   * the existing polyglot Context is reused, preventing a memory leak under sustained load.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> The {@code autoStoreScriptVariables} feature is not supported for
+   * non-cachable engines like GraalJS. GraalJS evaluates scripts inside a native polyglot
+   * Context and does not write script-local variables back to the Java bindings object.
+   * Use explicit {@code execution.setVariable()} calls inside scripts to persist variables.
+   * </p>
+   */
+  protected Bindings createBindingsForNonCachableEngine(ScriptEngine scriptEngine, VariableScope variableScope) {
+    Bindings engineBindings = scriptEngine.getBindings(ScriptContext.ENGINE_SCOPE);
+    for (ResolverFactory resolverFactory : scriptBindingsFactory.getResolverFactories()) {
+      Resolver resolver = resolverFactory.createResolver(variableScope);
+      if (resolver != null) {
+        for (String key : resolver.keySet()) {
+          engineBindings.put(key, resolver.get(key));
+        }
+      }
+    }
+    return engineBindings;
+  }
+
+  /**
+   * Checks if the given script engine is cachable ({@code THREADING} parameter is not null).
+   * Non-cachable engines like GraalJS require special bindings handling to avoid
+   * creating additional polyglot Contexts per evaluation. They do not support the {@code THREADING} parameter.
+   */
+  public static boolean isCachableEngine(ScriptEngine scriptEngine) {
+    Object threading = scriptEngine.getFactory().getParameter("THREADING");
+    return threading != null;
   }
 
   public ScriptBindingsFactory getScriptBindingsFactory() {

--- a/engine/src/main/java/org/cibseven/bpm/engine/impl/scripting/env/ScriptingEnvironment.java
+++ b/engine/src/main/java/org/cibseven/bpm/engine/impl/scripting/env/ScriptingEnvironment.java
@@ -36,6 +36,8 @@ import org.cibseven.bpm.engine.impl.scripting.ExecutableScript;
 import org.cibseven.bpm.engine.impl.scripting.ScriptFactory;
 import org.cibseven.bpm.engine.impl.scripting.engine.ScriptingEngines;
 
+import static org.cibseven.bpm.engine.impl.ProcessEngineLogger.SCRIPT_LOGGER;
+
 /**
  * <p>The scripting environment contains scripts that provide an environment to
  * a user provided script. The environment may contain additional libraries
@@ -84,7 +86,11 @@ public class ScriptingEnvironment {
     // create bindings
     Bindings bindings = scriptingEngines.createBindings(scriptEngine, scope);
 
-    return execute(script, scope, bindings, scriptEngine);
+    try {
+      return execute(script, scope, bindings, scriptEngine);
+    } finally {
+      closeNonCachedEngine(scriptEngine);
+    }
   }
 
   public Object execute(ExecutableScript script, VariableScope scope, Bindings bindings, ScriptEngine scriptEngine) {
@@ -177,6 +183,26 @@ public class ScriptingEnvironment {
     }
 
     return scripts;
+  }
+
+  /**
+   * Closes a non-cached script engine that implements {@link AutoCloseable}.
+   * <p>
+   * Script engines that report {@code THREADING} as {@code null} are not cached
+   * by the engine resolver (see {@link ScriptingEngines#isCachableEngine(ScriptEngine)}).
+   * For such engines (e.g., GraalJS), each evaluation creates a fresh engine instance
+   * whose internal resources (polyglot context, AST caches, interop metadata) must be
+   * explicitly released to prevent memory leaks under sustained load.
+   * </p>
+   */
+  static void closeNonCachedEngine(ScriptEngine scriptEngine) {
+    if (scriptEngine instanceof AutoCloseable && !ScriptingEngines.isCachableEngine(scriptEngine)) {
+      try {
+        ((AutoCloseable) scriptEngine).close();
+      } catch (Exception e) {
+        SCRIPT_LOGGER.logClosingScriptEngineFailed(e);
+      }
+    }
   }
 
 }

--- a/engine/src/test/java/org/cibseven/bpm/engine/test/standalone/scripting/ScriptingEnginesTest.java
+++ b/engine/src/test/java/org/cibseven/bpm/engine/test/standalone/scripting/ScriptingEnginesTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Ported from operaton/operaton PR #2768. Adapted for CIB seven by the CIB seven contributors.
+ */
+package org.cibseven.bpm.engine.test.standalone.scripting;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import javax.script.Bindings;
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineFactory;
+import javax.script.ScriptEngineManager;
+import javax.script.SimpleBindings;
+
+import org.cibseven.bpm.engine.impl.core.variable.scope.AbstractVariableScope;
+import org.cibseven.bpm.engine.impl.scripting.engine.DefaultScriptEngineResolver;
+import org.cibseven.bpm.engine.impl.scripting.engine.Resolver;
+import org.cibseven.bpm.engine.impl.scripting.engine.ResolverFactory;
+import org.cibseven.bpm.engine.impl.scripting.engine.ScriptBindings;
+import org.cibseven.bpm.engine.impl.scripting.engine.ScriptBindingsFactory;
+import org.cibseven.bpm.engine.impl.scripting.engine.ScriptingEngines;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ScriptingEngines}, covering the non-cachable engine
+ * bindings path that prevents GraalJS memory leaks.
+ */
+public class ScriptingEnginesTest {
+
+  @Test
+  public void shouldIdentifyNonCachableEngineWhenThreadingIsNull() {
+    // given a script engine whose factory reports THREADING=null
+    ScriptEngine nonCachableEngine = mockEngineWithThreading(null);
+
+    // then
+    assertThat(ScriptingEngines.isCachableEngine(nonCachableEngine)).isFalse();
+  }
+
+  @Test
+  public void shouldIdentifyCachableEngineWhenThreadingIsSet() {
+    // given a script engine whose factory reports THREADING=MULTITHREADED
+    ScriptEngine cachableEngine = mockEngineWithThreading("MULTITHREADED");
+
+    // then
+    assertThat(ScriptingEngines.isCachableEngine(cachableEngine)).isTrue();
+  }
+
+  @Test
+  public void createBindingsShouldReturnEngineScopeForNonCachableEngine() {
+    // given a non-cachable script engine (THREADING=null) with own ENGINE_SCOPE bindings
+    ScriptEngine nonCachableEngine = mockEngineWithThreading(null);
+    Bindings engineScopeBindings = new SimpleBindings();
+    when(nonCachableEngine.getBindings(ScriptContext.ENGINE_SCOPE)).thenReturn(engineScopeBindings);
+
+    // given a scripting engines instance with empty resolver list (avoids variable scope lookups)
+    ScriptingEngines engines = new ScriptingEngines(
+        new ScriptBindingsFactory(List.of()),
+        new DefaultScriptEngineResolver(new ScriptEngineManager()));
+    AbstractVariableScope variableScope = mock(AbstractVariableScope.class);
+
+    // when
+    Bindings result = engines.createBindings(nonCachableEngine, variableScope);
+
+    // then the ENGINE_SCOPE bindings are returned directly (not wrapped in ScriptBindings)
+    assertThat(result).isSameAs(engineScopeBindings);
+  }
+
+  @Test
+  public void createBindingsShouldPopulateResolverValuesForNonCachableEngine() {
+    // given a non-cachable engine
+    ScriptEngine nonCachableEngine = mockEngineWithThreading(null);
+    Bindings engineScopeBindings = new SimpleBindings();
+    when(nonCachableEngine.getBindings(ScriptContext.ENGINE_SCOPE)).thenReturn(engineScopeBindings);
+
+    // given a custom resolver that exposes a variable
+    ScriptBindingsFactory factory = createBindingsFactoryWithVariable("myVar", "myValue");
+    DefaultScriptEngineResolver resolver = new DefaultScriptEngineResolver(new ScriptEngineManager());
+    ScriptingEngines engines = new ScriptingEngines(factory, resolver);
+
+    AbstractVariableScope variableScope = mock(AbstractVariableScope.class);
+
+    // when
+    Bindings result = engines.createBindings(nonCachableEngine, variableScope);
+
+    // then the resolver variable is present in the returned bindings
+    assertThat(result).containsEntry("myVar", "myValue");
+  }
+
+  @Test
+  public void createBindingsShouldReturnScriptBindingsForCachableEngine() {
+    // given a cachable script engine (THREADING=MULTITHREADED)
+    ScriptEngine cachableEngine = mockEngineWithThreading("MULTITHREADED");
+    when(cachableEngine.createBindings()).thenReturn(new SimpleBindings());
+
+    ScriptingEngines engines = new ScriptingEngines(
+        new ScriptBindingsFactory(List.of()),
+        new DefaultScriptEngineResolver(new ScriptEngineManager()));
+    AbstractVariableScope variableScope = mock(AbstractVariableScope.class);
+
+    // when
+    Bindings result = engines.createBindings(cachableEngine, variableScope);
+
+    // then the result is a ScriptBindings (not the raw ENGINE_SCOPE)
+    assertThat(result).isInstanceOf(ScriptBindings.class);
+  }
+
+  // --- helpers ---
+
+  private static ScriptEngine mockEngineWithThreading(String threading) {
+    ScriptEngineFactory factory = mock(ScriptEngineFactory.class);
+    when(factory.getParameter("THREADING")).thenReturn(threading);
+    ScriptEngine engine = mock(ScriptEngine.class);
+    when(engine.getFactory()).thenReturn(factory);
+    return engine;
+  }
+
+  private static ScriptBindingsFactory createBindingsFactoryWithVariable(String key, Object value) {
+    ResolverFactory resolverFactory = variableScope -> new Resolver() {
+      @Override
+      public boolean containsKey(Object k) {
+        return key.equals(k);
+      }
+
+      @Override
+      public Object get(Object k) {
+        return key.equals(k) ? value : null;
+      }
+
+      @Override
+      public Set<String> keySet() {
+        return Collections.singleton(key);
+      }
+    };
+    return new ScriptBindingsFactory(List.of(resolverFactory));
+  }
+}


### PR DESCRIPTION
This PR is based on operaton/operaton#2768.
Thanks @kthoms for the original implementation!

## Summary
Backports the GraalJS polyglot `Context` leak fix. Under sustained load,
JavaScript script tasks (e.g. Spin/JSON transformations) leaked a polyglot
`Context` (~1 MB) per evaluation because GraalJS reports `THREADING=null`
(never cached) and its bindings were wrapped, forcing a fresh Context each time.

## Changes
- **Engine** – use the engine's native `ENGINE_SCOPE` bindings for non-cachable
  engines (GraalJS) so the existing Context is reused; close non-cached engines
  after evaluation.
- **DMN** – guard script compilation to cachable engines; close non-cached
  engines after evaluation.
- **HTTP connector** – null out the buffered response after reading so it can be
  garbage-collected.
- **Connect plugin** – close the connector response in a `try/finally` after
  output mapping.
- **Tests** – ported/added unit and regression tests.

## Backport notes
- Source: operaton/operaton#2768 (commit `58ff693`)
- Original issue: operaton/operaton#2761
- Original author: **@kthoms**
- Adapted to the `org.cibseven.bpm` namespace and converted JUnit 5 → JUnit 4
  to match CIB seven conventions.