### PR TITLE
chore: remove legacy license book leftovers

### DIFF
--- a/connect/connectors-all/pom.xml
+++ b/connect/connectors-all/pom.xml
@@ -10,12 +10,6 @@
   <artifactId>cibseven-connect-connectors-all</artifactId>
   <name>CIB seven - connect - all connectors in one</name>
 
-  <properties>
-    <!-- We shade artifacts into the jar, so we need to generate 
-    a dependency BOM for the license book -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-  </properties>
-
   <dependencies>
 
     <dependency>

--- a/distro/jboss/webapp/pom.xml
+++ b/distro/jboss/webapp/pom.xml
@@ -12,12 +12,6 @@
   <artifactId>cibseven-webapp-jboss</artifactId>
   <packaging>war</packaging>
   
-  <properties>
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-  </properties>
 
   <dependencies>
     <dependency>

--- a/distro/run/assembly/pom.xml
+++ b/distro/run/assembly/pom.xml
@@ -13,12 +13,6 @@
   <name>CIB seven - Run - Assembly</name>
   <packaging>pom</packaging>
   
-  <properties>
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-  </properties>
 
   <dependencyManagement>
     <dependencies>

--- a/distro/run/core/pom.xml
+++ b/distro/run/core/pom.xml
@@ -13,15 +13,6 @@
   <name>CIB seven - Run - Core</name>
   <packaging>jar</packaging>
 
-  <properties>
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-    <!-- snakeyaml is in Spring Boot's runtime scope and then included in our uberjar -->
-    <third-party-bom-scopes>compile|runtime</third-party-bom-scopes>
-  </properties>
-
   <dependencies>
 
     <dependency>

--- a/distro/run/modules/ai-agent/pom.xml
+++ b/distro/run/modules/ai-agent/pom.xml
@@ -13,13 +13,6 @@
   <name>CIB seven - Run - Module AI Agent</name>
   <packaging>pom</packaging>
 
-  <properties>
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-  </properties>
-
   <dependencies>
 
     <dependency>

--- a/distro/run/modules/example/pom.xml
+++ b/distro/run/modules/example/pom.xml
@@ -11,12 +11,6 @@
   <artifactId>cibseven-bpm-run-modules-example-invoice</artifactId>
   <name>CIB seven - Run - Module Example Invoice</name>
   
-  <properties>
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-  </properties>
 
   <dependencies>
 

--- a/distro/run/modules/http-client/pom.xml
+++ b/distro/run/modules/http-client/pom.xml
@@ -13,13 +13,6 @@
   <name>CIB seven - Run - Module HTTP Connector</name>
   <packaging>pom</packaging>
 
-  <properties>
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-  </properties>
-
   <dependencies>
 
     <dependency>

--- a/distro/run/modules/oauth2/pom.xml
+++ b/distro/run/modules/oauth2/pom.xml
@@ -13,12 +13,6 @@
   <name>CIB seven - Run - Module Spring Security</name>
   <packaging>pom</packaging>
   
-  <properties>
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-  </properties>
   
   <dependencies>
 

--- a/distro/run/modules/rest/pom.xml
+++ b/distro/run/modules/rest/pom.xml
@@ -13,12 +13,6 @@
   <name>CIB seven - Run - Module REST</name>
   <packaging>pom</packaging>
   
-  <properties>
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-  </properties>
 
   <dependencies>
 

--- a/distro/run/modules/soap-http-client/pom.xml
+++ b/distro/run/modules/soap-http-client/pom.xml
@@ -13,13 +13,6 @@
   <name>CIB seven - Run - Module SOAP Connector</name>
   <packaging>pom</packaging>
 
-  <properties>
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-  </properties>
-
   <dependencies>
 
     <dependency>

--- a/distro/run/modules/webapps/pom.xml
+++ b/distro/run/modules/webapps/pom.xml
@@ -13,12 +13,6 @@
   <name>CIB seven - Run - Module Webapps</name>
   <packaging>pom</packaging>
   
-  <properties>
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-  </properties>
   
   <dependencies>
 

--- a/distro/run4/assembly/pom.xml
+++ b/distro/run4/assembly/pom.xml
@@ -13,12 +13,6 @@
   <name>CIB seven - Run 4 - Assembly</name>
   <packaging>pom</packaging>
   
-  <properties>
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-  </properties>
 
   <dependencyManagement>
     <dependencies>

--- a/distro/run4/core/pom.xml
+++ b/distro/run4/core/pom.xml
@@ -13,15 +13,6 @@
   <name>CIB seven - Run 4 - Core</name>
   <packaging>jar</packaging>
 
-  <properties>
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-    <!-- snakeyaml is in Spring Boot's runtime scope and then included in our uberjar -->
-    <third-party-bom-scopes>compile|runtime</third-party-bom-scopes>
-  </properties>
-
   <dependencies>
 
     <dependency>

--- a/distro/run4/modules/ai-agent/pom.xml
+++ b/distro/run4/modules/ai-agent/pom.xml
@@ -13,13 +13,6 @@
   <name>CIB seven - Run 4 - Module AI Agent</name>
   <packaging>pom</packaging>
 
-  <properties>
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-  </properties>
-
   <dependencies>
 
     <dependency>

--- a/distro/run4/modules/example/pom.xml
+++ b/distro/run4/modules/example/pom.xml
@@ -11,12 +11,6 @@
   <artifactId>cibseven-bpm-run4-modules-example-invoice</artifactId>
   <name>CIB seven - Run 4 - Module Example Invoice</name>
   
-  <properties>
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-  </properties>
 
   <dependencies>
 

--- a/distro/run4/modules/http-client/pom.xml
+++ b/distro/run4/modules/http-client/pom.xml
@@ -13,13 +13,6 @@
   <name>CIB seven - Run 4 - Module HTTP Connector</name>
   <packaging>pom</packaging>
 
-  <properties>
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-  </properties>
-
   <dependencies>
 
     <dependency>

--- a/distro/run4/modules/oauth2/pom.xml
+++ b/distro/run4/modules/oauth2/pom.xml
@@ -13,12 +13,6 @@
   <name>CIB seven - Run 4 - Module Spring Security</name>
   <packaging>pom</packaging>
   
-  <properties>
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-  </properties>
   
   <dependencies>
 

--- a/distro/run4/modules/rest/pom.xml
+++ b/distro/run4/modules/rest/pom.xml
@@ -13,12 +13,6 @@
   <name>CIB seven - Run 4 - Module REST</name>
   <packaging>pom</packaging>
   
-  <properties>
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-  </properties>
 
   <dependencies>
 

--- a/distro/run4/modules/soap-http-client/pom.xml
+++ b/distro/run4/modules/soap-http-client/pom.xml
@@ -13,13 +13,6 @@
   <name>CIB seven - Run 4 - Module SOAP Connector</name>
   <packaging>pom</packaging>
 
-  <properties>
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-  </properties>
-
   <dependencies>
 
     <dependency>

--- a/distro/run4/modules/webapps/pom.xml
+++ b/distro/run4/modules/webapps/pom.xml
@@ -13,12 +13,6 @@
   <name>CIB seven - Run 4 - Module Webapps</name>
   <packaging>pom</packaging>
   
-  <properties>
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-  </properties>
   
   <dependencies>
 

--- a/distro/tomcat/ai-agent/pom.xml
+++ b/distro/tomcat/ai-agent/pom.xml
@@ -13,13 +13,6 @@
   <name>CIB seven - tomcat - AI Agent overlay</name>
   <packaging>pom</packaging>
 
-  <properties>
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-  </properties>
-
   <!-- CIB7-1426: langchain4j 1.16.3 transitively pulls jackson-core/databind 2.21.3
        (CVE-2026-54512 / CVE-2026-54513), fixed in 2.21.4. Tomcat is the ONLY distro
        where langchain4j's Jackson is authoritative on the runtime classpath: the

--- a/distro/tomcat/ai-agent/pom.xml
+++ b/distro/tomcat/ai-agent/pom.xml
@@ -71,10 +71,9 @@
               <goal>copy-dependencies</goal>
             </goals>
             <configuration>
-              <!-- Pin the output to target/dependency, matching the path the tomcat
-                   assembly reads (../ai-agent/target/dependency/). Explicit so the
-                   third-party-bom tooling's generated-resources outputDirectory can
-                   never leak into this execution. -->
+              <!-- Same as the plugin default, pinned explicitly because this path is a
+                   cross-module contract: distro/tomcat/assembly/assembly.xml reads
+                   ../ai-agent/target/dependency/ as a literal fileSet directory. -->
               <outputDirectory>${project.build.directory}/dependency</outputDirectory>
               <includeScope>runtime</includeScope>
             </configuration>

--- a/distro/tomcat/assembly/pom.xml
+++ b/distro/tomcat/assembly/pom.xml
@@ -15,9 +15,6 @@
     <version>2.3.0-SNAPSHOT</version>
   </parent>
   
-  <properties>
-    <skip-third-party-bom>false</skip-third-party-bom>
-  </properties>
 
   <name>CIB seven - tomcat Assembly</name>
 

--- a/distro/tomcat/webapp-jakarta/pom.xml
+++ b/distro/tomcat/webapp-jakarta/pom.xml
@@ -13,8 +13,6 @@
   <packaging>war</packaging>
   
   <properties>
-    <skip-third-party-bom>false</skip-third-party-bom>
-
     <version.resteasy>6.2.3.Final</version.resteasy>
   </properties>
 

--- a/distro/wildfly/ai-agent/pom.xml
+++ b/distro/wildfly/ai-agent/pom.xml
@@ -13,13 +13,6 @@
   <name>CIB seven - Wildfly - AI Agent module collector</name>
   <packaging>pom</packaging>
 
-  <properties>
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-  </properties>
-
   <dependencies>
 
     <dependency>

--- a/distro/wildfly/ai-agent/pom.xml
+++ b/distro/wildfly/ai-agent/pom.xml
@@ -49,11 +49,9 @@
               <goal>copy-dependencies</goal>
             </goals>
             <configuration>
-              <!-- Pin the output to target/dependency. The third-party-bom tooling
-                   inherited from the parent configures maven-dependency-plugin with
-                   outputDirectory=target/generated-resources at plugin level, which
-                   would otherwise leak into this execution; the wildfly modules build
-                   reads the collected jars from ../ai-agent/target/dependency. -->
+              <!-- Same as the plugin default, pinned explicitly because this path is a
+                   cross-module contract: distro/wildfly/modules/pom.xml copies from
+                   ../ai-agent/target/dependency as a literal antrun fileset. -->
               <outputDirectory>${project.build.directory}/dependency</outputDirectory>
               <includeScope>runtime</includeScope>
               <!-- slf4j + jackson are provided by their own WildFly modules (the

--- a/distro/wildfly/assembly/pom.xml
+++ b/distro/wildfly/assembly/pom.xml
@@ -17,12 +17,6 @@
     The assembly is installed to maven later in the reactor, if the integration tests pass successfully
   </description>
   
-  <properties>
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-  </properties>
 
   <dependencies>
     <dependency>

--- a/distro/wildfly/modules/pom.xml
+++ b/distro/wildfly/modules/pom.xml
@@ -13,12 +13,6 @@
 
   <properties>
     <org.jboss.shrinkwrap.resolver.version>2.2.7</org.jboss.shrinkwrap.resolver.version>
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-    <!-- json-smart and accessors-smart are runtime dependencies of json-path -->
-    <third-party-bom-scopes>compile|runtime</third-party-bom-scopes>
   </properties>
   
   <dependencies>

--- a/distro/wildfly/webapp/pom.xml
+++ b/distro/wildfly/webapp/pom.xml
@@ -12,13 +12,6 @@
   <artifactId>cibseven-webapp-wildfly</artifactId>
   <packaging>war</packaging>
 
-  <properties>
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.cibseven.bpm.webapp</groupId>

--- a/distro/wildfly28/assembly/pom.xml
+++ b/distro/wildfly28/assembly/pom.xml
@@ -17,12 +17,6 @@
     The assembly is installed to maven later in the reactor, if the integration tests pass successfully
   </description>
   
-  <properties>
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-  </properties>
 
   <dependencies>
     <dependency>

--- a/distro/wildfly28/modules/pom.xml
+++ b/distro/wildfly28/modules/pom.xml
@@ -13,12 +13,6 @@
 
   <properties>
     <org.jboss.shrinkwrap.resolver.version>2.2.7</org.jboss.shrinkwrap.resolver.version>
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-    <!-- json-smart and accessors-smart are runtime dependencies of json-path -->
-    <third-party-bom-scopes>compile|runtime</third-party-bom-scopes>
   </properties>
 
   <dependencies>

--- a/engine-rest/assembly-jakarta/pom.xml
+++ b/engine-rest/assembly-jakarta/pom.xml
@@ -12,13 +12,6 @@
   </parent>
 
   <properties>
-    <!-- generate a bom of dependencies for the license book.
-    We include compile and provided scope dependencies;
-    all the dependencies that we include in only one of the
-    runtime-specific-WARs are in provided scope -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-    <third-party-bom-scopes>compile|provided</third-party-bom-scopes>
-
     <version.resteasy>6.2.3.Final</version.resteasy>
   </properties>
 

--- a/engine-rest/assembly/pom.xml
+++ b/engine-rest/assembly/pom.xml
@@ -10,15 +10,6 @@
     <relativePath>../</relativePath>
     <version>2.3.0-SNAPSHOT</version>
   </parent>
-  
-  <properties>
-    <!-- generate a bom of dependencies for the license book.
-    We include compile and provided scope dependencies; 
-    all the dependencies that we include in only one of the 
-    runtime-specific-WARs are in provided scope -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-    <third-party-bom-scopes>compile|provided</third-party-bom-scopes>
-  </properties>
 
   <dependencies>
     <dependency>

--- a/engine-rest/docs/pom.xml
+++ b/engine-rest/docs/pom.xml
@@ -11,10 +11,6 @@
   <name>CIB seven - engine - REST - Docs</name>
   <packaging>pom</packaging>
 
-  <properties>
-    <skip-third-party-bom>true</skip-third-party-bom>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.cibseven.bpm</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -367,10 +367,6 @@
     <authorizationCheckRevokes>auto</authorizationCheckRevokes>
     <jdbcBatchProcessing>true</jdbcBatchProcessing>
 
-    <!-- We shade artifacts into the jar, so we need to generate a dependency BOM
-    for the license book -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-
     <cibseven.artifact>
       org.cibseven.bpm
     </cibseven.artifact>

--- a/juel/pom.xml
+++ b/juel/pom.xml
@@ -17,9 +17,6 @@
     <!-- We only wrap and maintain external code in here that has
     its own license header already -->
     <license.skip>true</license.skip>
-    <!-- We shade artifacts into the jar, so we need to generate
-    a dependency BOM for the license book -->
-    <skip-third-party-bom>false</skip-third-party-bom>
     <!-- Using Jakarta Expression Language 4.0 for Java 8 compatibility -->
     <version.jakarta.el>4.0.0</version.jakarta.el>
   </properties>

--- a/spin/dataformat-all/pom.xml
+++ b/spin/dataformat-all/pom.xml
@@ -10,13 +10,6 @@
   <artifactId>cibseven-spin-dataformat-all</artifactId>
   <name>CIB seven Spin - all dataformats in one</name>
 
-  <properties>
-    <!-- We shade artifacts into the jar, so we need to generate 
-    a dependency BOM for the license book -->
-    <skip-third-party-bom>false</skip-third-party-bom>
-    <!-- json-smart and accessors-smart are runtime dependencies of json-path -->
-    <third-party-bom-scopes>compile|runtime</third-party-bom-scopes>
-  </properties>
   
   <dependencies>
 

--- a/webapps/assembly-jakarta/pom.xml
+++ b/webapps/assembly-jakarta/pom.xml
@@ -25,11 +25,6 @@
     <web.resources.override>${jakarta.runtime}/default/webapp</web.resources.override>
     <java.resources.override>${jakarta.runtime}/default/resources</java.resources.override>
     <properties.override>${jakarta.runtime}/default/config.properties</properties.override>
-
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
   </properties>
 
   <dependencyManagement>

--- a/webapps/assembly/pom.xml
+++ b/webapps/assembly/pom.xml
@@ -18,11 +18,6 @@
   <properties>
     <java.resources.override>src/main/runtime/default/resources</java.resources.override>
     <properties.override>src/main/runtime/default/config.properties</properties.override>
-
-    <!-- generate a bom of compile time dependencies for the license book.
-    Note: Every compile time dependency will end up in the license book. Please
-    declare only dependencies that are actually needed -->
-    <skip-third-party-bom>false</skip-third-party-bom>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Apply changes after testing and merging release-parent changes: cibseven/cibseven-release-parent#18