### PR TITLE
chore: bump maven-dependency-plugin to 3.11.0 and unify versions

### DIFF
--- a/distro/run/modules/example/pom.xml
+++ b/distro/run/modules/example/pom.xml
@@ -41,8 +41,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <!-- override version to use fileMappers -->
-        <version>3.2.0</version>
         <executions>
           <execution>
             <id>unpack-invoice</id>

--- a/distro/run4/modules/example/pom.xml
+++ b/distro/run4/modules/example/pom.xml
@@ -41,8 +41,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <!-- override version to use fileMappers -->
-        <version>3.2.0</version>
         <executions>
           <execution>
             <id>unpack-invoice</id>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -228,7 +228,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>2.8</version>
+          <version>3.11.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cibseven</groupId>
     <artifactId>release-parent</artifactId>
-    <version>1.6.0</version>
+    <version>1.7.0-SNAPSHOT</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
     <relativePath />
   </parent>

--- a/webapps/assembly/pom.xml
+++ b/webapps/assembly/pom.xml
@@ -471,7 +471,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
-            <version>2.10</version>
             <executions>
               <execution>
                 <id>copy</id>

--- a/webapps/pom.xml
+++ b/webapps/pom.xml
@@ -235,11 +235,6 @@
         <!-- code plugins -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-dependency-plugin</artifactId>
-          <version>2.8</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
           <version>2.6</version>
         </plugin>


### PR DESCRIPTION
Apply changes after testing and merging release-parent changes: https://github.com/cibseven/cibseven-release-parent/pull/18
Otherwise, build will fail for run/modules/example (sb3 and sb4 flavours) due the overriding maven-dependency-plugin 2.8 (from release-parent)