### PR TITLE
chore: downgrade log4j from 2.26.1 to 2.25.5

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -53,7 +53,7 @@
 
     <version.slf4j>1.7.36</version.slf4j>
     <version.logback>1.2.13</version.logback>
-    <version.log4j2>2.25.4</version.log4j2>
+    <version.log4j2>2.25.5</version.log4j2>
     <version.junit>4.13.1</version.junit>
     <version.assertj>2.9.1</version.assertj>
     <version.mockito>5.17.0</version.mockito>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -53,7 +53,7 @@
 
     <version.slf4j>1.7.36</version.slf4j>
     <version.logback>1.2.13</version.logback>
-    <version.log4j2>2.26.1</version.log4j2>
+    <version.log4j2>2.25.4</version.log4j2>
     <version.junit>4.13.1</version.junit>
     <version.assertj>2.9.1</version.assertj>
     <version.mockito>5.17.0</version.mockito>


### PR DESCRIPTION
So it's aligned to log4j version of Spring Boot