### PR TITLE
chore(deps): override http5 libs used inside SB with updated versions

### DIFF
--- a/distro/run/pom.xml
+++ b/distro/run/pom.xml
@@ -34,6 +34,24 @@
         <type>pom</type>
       </dependency>
 
+      <!-- Temporary Apache HttpComponents CVE overrides.
+           Remove these once the imported Spring Boot BOM manages fixed versions. -->
+      <dependency>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
+        <version>${version.httpclient5}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5</artifactId>
+        <version>${version.httpcore5}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5-h2</artifactId>
+        <version>${version.httpcore5}</version>
+      </dependency>
+
       <dependency>
         <groupId>org.graalvm.js</groupId>
         <artifactId>js</artifactId>

--- a/distro/run4/pom.xml
+++ b/distro/run4/pom.xml
@@ -48,6 +48,24 @@
         <type>pom</type>
       </dependency>
 
+      <!-- Temporary Apache HttpComponents CVE overrides.
+           Remove these once the imported Spring Boot BOM manages fixed versions. -->
+      <dependency>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
+        <version>${version.httpclient5}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5</artifactId>
+        <version>${version.httpcore5}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5-h2</artifactId>
+        <version>${version.httpcore5}</version>
+      </dependency>
+
       <dependency>
         <groupId>org.graalvm.js</groupId>
         <artifactId>js</artifactId>

--- a/distro/wildfly/modules/src/main/modules/org/apache/httpcomponents/client5/httpclient5/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/apache/httpcomponents/client5/httpclient5/main/module.xml
@@ -8,6 +8,8 @@
     <module name="java.base" />
     <module name="java.naming" />
     <module name="java.security.jgss" />
+    <!-- required for extended TCP socket options (TCP_KEEPIDLE/INTERVAL/COUNT) used by the I/O reactor -->
+    <module name="jdk.net" />
 
     <module name="org.slf4j" />
     <module name="org.apache.httpcomponents.core5.httpcore5" export="true" />

--- a/distro/wildfly/modules/src/main/modules/org/apache/httpcomponents/core5/httpcore5/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/apache/httpcomponents/core5/httpcore5/main/module.xml
@@ -7,6 +7,8 @@
   <dependencies>
 
     <module name="java.base" />
+    <!-- required for extended TCP socket options (TCP_KEEPIDLE/INTERVAL/COUNT) used by the I/O reactor -->
+    <module name="jdk.net" />
     <module name="org.slf4j" />
 
   </dependencies>

--- a/distro/wildfly28/modules/src/main/modules/org/apache/httpcomponents/client5/httpclient5/main/module.xml
+++ b/distro/wildfly28/modules/src/main/modules/org/apache/httpcomponents/client5/httpclient5/main/module.xml
@@ -8,6 +8,8 @@
     <module name="java.base" />
     <module name="java.naming" />
     <module name="java.security.jgss" />
+    <!-- required for extended TCP socket options (TCP_KEEPIDLE/INTERVAL/COUNT) used by the I/O reactor -->
+    <module name="jdk.net" />
 
     <module name="org.slf4j" />
     <module name="org.apache.httpcomponents.core5.httpcore5" export="true" />

--- a/distro/wildfly28/modules/src/main/modules/org/apache/httpcomponents/core5/httpcore5/main/module.xml
+++ b/distro/wildfly28/modules/src/main/modules/org/apache/httpcomponents/core5/httpcore5/main/module.xml
@@ -7,6 +7,8 @@
   <dependencies>
 
     <module name="java.base" />
+    <!-- required for extended TCP socket options (TCP_KEEPIDLE/INTERVAL/COUNT) used by the I/O reactor -->
+    <module name="jdk.net" />
     <module name="org.slf4j" />
 
   </dependencies>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -182,6 +182,24 @@
         <version>${version.log4j2}</version>
       </dependency>
 
+      <!-- Temporary Apache HttpComponents CVE overrides.
+           Remove these once the imported Spring Boot BOM manages fixed versions. -->
+      <dependency>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
+        <version>${version.httpclient5}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5</artifactId>
+        <version>${version.httpcore5}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5-h2</artifactId>
+        <version>${version.httpcore5}</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 

--- a/spring-boot-4-starter/pom.xml
+++ b/spring-boot-4-starter/pom.xml
@@ -54,6 +54,25 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
+
+      <!-- Temporary Apache HttpComponents CVE overrides.
+           Remove these once the imported Spring Boot BOM manages fixed versions. -->
+      <dependency>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
+        <version>${version.httpclient5}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5</artifactId>
+        <version>${version.httpcore5}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5-h2</artifactId>
+        <version>${version.httpcore5}</version>
+      </dependency>
+
       <!-- Direct override: spring-context 6.2.x leaks via cibseven BOM chain; pin to 7.0.6 -->
       <dependency>
         <groupId>org.springframework</groupId>

--- a/spring-boot-starter/pom.xml
+++ b/spring-boot-starter/pom.xml
@@ -38,6 +38,24 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
+
+      <!-- Temporary Apache HttpComponents CVE overrides.
+           Remove these once the imported Spring Boot BOM manages fixed versions. -->
+      <dependency>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
+        <version>${version.httpclient5}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5</artifactId>
+        <version>${version.httpcore5}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5-h2</artifactId>
+        <version>${version.httpcore5}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   


### PR DESCRIPTION
- replaced internal SB dependencies to http5 libs with the new http5 versions
- added "jdk.net" to wildfly and wildfly28 module.xml templates, for both httpcore5 and httpclient5