### PR TITLE
chore(wildfly): patch log4j-api to address CVE-2026-49844

### DIFF
--- a/distro/wildfly/assembly/assembly.xml
+++ b/distro/wildfly/assembly/assembly.xml
@@ -35,6 +35,9 @@
           <!-- exclude wildfly's shipped lz4-java (CVE-2026-59949); replaced by the
                at/yawk/lz4 module from ../modules, see version.lz4-java -->
           <exclude>**/at/yawk/lz4/**</exclude>
+          <!-- exclude wildfly's shipped log4j-api (CVE-2026-49844); replaced by the
+               org/apache/logging/log4j/api module from ../modules, see version.log4j2 -->
+          <exclude>**/org/apache/logging/log4j/api/**</exclude>
         </excludes>
       </unpackOptions>
     </dependencySet>

--- a/distro/wildfly/modules/pom.xml
+++ b/distro/wildfly/modules/pom.xml
@@ -166,6 +166,17 @@
       <version>${version.lz4-java}</version>
     </dependency>
 
+      <!-- Patched log4j-api replacing the 2.25.4 jar bundled in wildfly-dist (CVE-2026-49844).
+         WildFly's system module is excluded from the distro.
+         copy-dependencies step below already maps <groupId path>/<version>/<jar> to
+         <groupId path>/main/<jar>, which is exactly the layout the module.xml expects.
+         Drop this once WildFly ships log4j >= 2.25.4 -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${version.log4j2}</version>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -308,6 +319,20 @@
                 </copy>
                 <delete dir="target/modules/org/apache/httpcomponents/core5/httpcore5-h2" />
 
+                <!-- log4j-api (CVE-2026-49844): the generic copy above derives the module
+                     dir from the coordinates, landing the jar in
+                     org/apache/logging/log4j/log4j-api/main. WildFly's module is named
+                     org.apache.logging.log4j.api -->
+                <move todir="target/modules" flatten="false">
+                  <fileset dir="target/modules">
+                    <include name="org/apache/logging/log4j/log4j-api/main/*.jar" />
+                  </fileset>
+                  <regexpmapper from="^org/apache/logging/log4j/log4j-api/main/(.*)$$"
+                                to="org/apache/logging/log4j/api/main/\1"
+                                handledirsep="yes" />
+                </move>
+                <delete dir="target/modules/org/apache/logging/log4j/log4j-api" />
+
                 <!-- move caffeine into its own slot, so that we do not shadow the
                   caffeine module WildFly provides for Infinispan -->
                 <delete dir="target/modules/com/github/ben-manes/caffeine" />
@@ -442,6 +467,10 @@
                 </replace>
 
                 <replace dir="target/modules" token="@version.lz4-java@" value="${version.lz4-java}">
+                  <include name="**/module.xml" />
+                </replace>
+
+                <replace dir="target/modules" token="@version.log4j2@" value="${version.log4j2}">
                   <include name="**/module.xml" />
                 </replace>
 

--- a/distro/wildfly/modules/src/main/modules/at/yawk/lz4/lz4-java/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/at/yawk/lz4/lz4-java/main/module.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
 <!--
   Replaces the lz4-java module shipped inside wildfly-dist, which pins 1.10.4 and
   is flagged for CVE-2026-59949. WildFly's copy of this module is excluded from the

--- a/distro/wildfly/modules/src/main/modules/org/apache/logging/log4j/api/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/apache/logging/log4j/api/main/module.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+<!--
+  Replaces the log4j-api module shipped inside wildfly-dist, which pins 2.25.4 and
+  is flagged for CVE-2026-49844. WildFly's copy of this module is excluded from the
+  distro unpack (see distro/wildfly/assembly/assembly.xml) so only this one ships.
+  Layout and the private jboss.api marker are kept identical to WildFly's original;
+  only the jar version differs (version.log4j-api in parent/pom.xml).
+  -->
+<module name="org.apache.logging.log4j.api" xmlns="urn:jboss:module:1.9">
+
+    <properties>
+        <property name="jboss.api" value="public"/>
+    </properties>
+
+    <resources>
+        <resource-root path="log4j-api-@version.log4j2@.jar"/>
+    </resources>
+
+    <dependencies>
+        <!--
+            This is a circular dependency to avoid adding the private implementation to a dependent module. The API uses
+            static variables for the providers and factories. These are located through a custom service loader and we
+            should bind to this implementation only. Users wanting to not use this implementation need to also not use
+            this API.
+        -->
+        <module name="org.jboss.logmanager.log4j2" services="import"/>
+    </dependencies>
+</module>


### PR DESCRIPTION
Accept in case that Wildfly 41.0.1 doesn't update log4j-api version to 2.25.5