### PR TITLE
fix(engine): bracket the OR in the user query id criterion

### DIFF
--- a/engine/src/main/resources/org/cibseven/bpm/engine/impl/mapping/entity/User.xml
+++ b/engine/src/main/resources/org/cibseven/bpm/engine/impl/mapping/entity/User.xml
@@ -118,9 +118,7 @@
     
     <where>
       <if test="id != null">
-        RES.ID_ = #{id}
-	        OR
-        LOWER(RES.ID_) = LOWER(#{id})
+        (RES.ID_ = #{id} OR LOWER(RES.ID_) = LOWER(#{id}))
       </if>
       <if test="ids != null &amp;&amp; ids.length > 0">
         and RES.ID_ in

--- a/engine/src/test/java/org/cibseven/bpm/engine/test/api/identity/IdentityServiceAuthorizationsTest.java
+++ b/engine/src/test/java/org/cibseven/bpm/engine/test/api/identity/IdentityServiceAuthorizationsTest.java
@@ -935,6 +935,56 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
 
   }
 
+  /**
+   * The user id criterion matches case-insensitively, i.e. it consists of two conditions
+   * combined with OR. If those are not bracketed, the AND of the authorization check binds
+   * tighter than the OR and an exact id match bypasses the check altogether.
+   */
+  @Test
+  public void testUserQueryAuthorizationsWithUserIdCriterion() {
+
+    // we are jonny2
+    String authUserId = "jonny2";
+    identityService.setAuthenticatedUserId(authUserId);
+
+    // create new user jonny1
+    User jonny1 = identityService.newUser("jonny1");
+    identityService.saveUser(jonny1);
+
+    // set base permission for all users (no-one has any permissions on users)
+    Authorization basePerms = authorizationService.createNewAuthorization(AUTH_TYPE_GLOBAL);
+    basePerms.setResource(USER);
+    basePerms.setResourceId(ANY);
+    authorizationService.saveAuthorization(basePerms);
+
+    // now enable checks
+    processEngineConfiguration.setAuthorizationEnabled(true);
+
+    // we cannot fetch the user by its id, neither exactly nor case-insensitively
+    assertNull(identityService.createUserQuery().userId("jonny1").singleResult());
+    assertEquals(0, identityService.createUserQuery().userId("jonny1").count());
+    assertNull(identityService.createUserQuery().userId("JONNY1").singleResult());
+    assertEquals(0, identityService.createUserQuery().userId("JONNY1").count());
+
+    processEngineConfiguration.setAuthorizationEnabled(false);
+
+    // now we add permission for jonny2 to read the user:
+    Authorization ourPerms = authorizationService.createNewAuthorization(AUTH_TYPE_GRANT);
+    ourPerms.setUserId(authUserId);
+    ourPerms.setResource(USER);
+    ourPerms.setResourceId(ANY);
+    ourPerms.addPermission(READ);
+    authorizationService.saveAuthorization(ourPerms);
+
+    processEngineConfiguration.setAuthorizationEnabled(true);
+
+    // now we can fetch the user by its id
+    assertNotNull(identityService.createUserQuery().userId("jonny1").singleResult());
+    assertEquals(1, identityService.createUserQuery().userId("jonny1").count());
+    assertNotNull(identityService.createUserQuery().userId("JONNY1").singleResult());
+    assertEquals(1, identityService.createUserQuery().userId("JONNY1").count());
+  }
+
   @Test
   public void testUserQueryAuthorizationsMultipleGroups() {
 

--- a/engine/src/test/java/org/cibseven/bpm/engine/test/api/identity/UserQueryTest.java
+++ b/engine/src/test/java/org/cibseven/bpm/engine/test/api/identity/UserQueryTest.java
@@ -96,6 +96,35 @@ public class UserQueryTest extends PluggableProcessEngineTest {
   }
 
   @Test
+  public void testQueryByIdCaseInsensitive() {
+    verifyQueryResults(identityService.createUserQuery().userId("KERMIT"), 1);
+    verifyQueryResults(identityService.createUserQuery().userId("Kermit"), 1);
+  }
+
+  /**
+   * The user id criterion matches case-insensitively, i.e. it consists of two conditions
+   * combined with OR. Those have to be bracketed, otherwise the AND of every subsequent
+   * criterion (including the authorization check) binds tighter than the OR and is
+   * short-circuited by an exact id match.
+   */
+  @Test
+  public void testQueryByIdCombinedWithOtherCriteria() {
+    // kermit matches the id but not the remaining criterion
+    verifyQueryResults(identityService.createUserQuery().userId("kermit").userFirstName("Fozzie"), 0);
+    verifyQueryResults(identityService.createUserQuery().userId("kermit").userLastName("Bear"), 0);
+    verifyQueryResults(identityService.createUserQuery().userId("kermit").userEmail("fozzie@muppetshow.com"), 0);
+    verifyQueryResults(identityService.createUserQuery().userId("kermit").memberOfGroup("nonExisting"), 0);
+    verifyQueryResults(identityService.createUserQuery().userId("kermit").memberOfTenant("nonExisting"), 0);
+
+    // same for a case-insensitive id match
+    verifyQueryResults(identityService.createUserQuery().userId("KERMIT").userFirstName("Fozzie"), 0);
+
+    // both criteria match
+    verifyQueryResults(identityService.createUserQuery().userId("kermit").userFirstName("Kermit_"), 1);
+    verifyQueryResults(identityService.createUserQuery().userId("KERMIT").userFirstName("Kermit_"), 1);
+  }
+
+  @Test
   public void testQueryByInvalidId() {
     UserQuery query = identityService.createUserQuery().userId("invalid");
     verifyQueryResults(query, 0);


### PR DESCRIPTION
CIB7-1918
The case-insensitive user id match introduced in aa509ee5cf emitted two conditions joined by an unbracketed OR:

  RES.ID_ = ? OR LOWER(RES.ID_) = LOWER(?)

Since AND binds tighter than OR, the generated statement parsed as

  RES.ID_ = ?  OR  (LOWER(RES.ID_) = LOWER(?) AND <all other criteria>)

so an exact id match short-circuited every subsequent criterion. Two consequences:

* Additional filters were silently ignored, e.g. createUserQuery().userId("kermit").userFirstName("Fozzie") returned kermit. Reachable over REST via GET /user?id=...&firstName=...
* queryAuthorizationCheck is ANDed in as well and the authorization join is a LEFT JOIN, so querying by user id bypassed the READ permission check on USER entirely. This affected GET /user?id=... and UserResourceImpl.findUserObject(). The login path is unaffected, as checkPassword() resolves the user via findUserById(), which performs its own explicit authorization check.

Bracketing both conditions restores the intended case-insensitive match while keeping the remaining criteria and the authorization check ANDed to the whole id predicate.

The existing tests missed this because UserQueryTest exercised every criterion in isolation and never combined userId with a second one, and testUserQueryAuthorizations only ever called createUserQuery() without criteria. Add regression coverage for both gaps.